### PR TITLE
Fix #171

### DIFF
--- a/aslprep/interfaces/cbf_computation.py
+++ b/aslprep/interfaces/cbf_computation.py
@@ -721,11 +721,24 @@ class _BASILCBFInputSpec(FSLCommandInputSpec):
     mzero = File(exists=True, argstr=" -c %s ", desc='m0 scan', mandatory=False)
     m0scale = traits.Float(desc='calibration of asl', argstr=" --cgain %.2f ", mandatory=True)
     m0tr = traits.Float(desc='Mzero TR', argstr=" --tr %.2f ", mandatory=True,)
-    tis = traits.Str(desc='recovery time =plds+bolus', argstr=" --tis %s ", mandatory=True,)
+    tis = traits.Either(
+        traits.Float(),
+        traits.List(traits.Float()),
+        desc='recovery time =plds+bolus',
+        argstr=" --tis %s ",
+        mandatory=True,
+        sep=',',
+    )
     pcasl = traits.Bool(desc='label type:defualt is PASL', argstr=" --casl ",
                         mandatory=False, default_value=False)
-    bolus = traits.Float(desc='bolus or tau: label duration', argstr=" --bolus %.2f ",
-                         mandatory=True)
+    bolus = traits.Either(
+        traits.Float(),
+        traits.List(traits.Float()),
+        desc='bolus or tau: label duration',
+        argstr="--bolus %s",
+        mandatory=True,
+        sep=',',
+    )
     pvc = traits.Bool(desc='calibration of asl', mandatory=False, argstr=" --pvcorr ",
                       default_value=True)
     pvgm = File(exists=True, mandatory=False, desc='grey matter probablity matter ',

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -97,13 +97,6 @@ The cerebral blood flow (CBF) was quantified from  preprocessed ASL data using a
     
     tiscbf = get_tis(metadata)
 
-    #tiscbf=np.add(metadata["PostLabelingDelay"],metadata["LabelingDuration"])
-
-    if hasattr(tiscbf, '__len__'):
-        tisasl = ",".join([str(i) for i in tiscbf])
-    else:
-        tisasl = str(tiscbf)
-
     def pcaslorasl(metadata):
         if 'CASL' in metadata["ArterialSpinLabelingType"]:
             pcasl1 = True
@@ -119,7 +112,7 @@ The cerebral blood flow (CBF) was quantified from  preprocessed ASL data using a
     scorescrub = pe.Node(scorescrubCBF(in_thresh=0.7, in_wfun='huber'), mem_gb=0.2,
                          name='scorescrub', run_without_submitting=True)
     basilcbf = pe.Node(BASILCBF(m0scale=M0Scale, bolus=metadata["LabelingDuration"],
-                                m0tr=metadata['RepetitionTime'], pvc=True,tis = tisasl,
+                                m0tr=metadata['RepetitionTime'], pvc=True, tis=tiscbf,
                                 pcasl = pcaslorasl(metadata = metadata)), name='basilcbf',
                        run_without_submitting=True, mem_gb=0.2)
 
@@ -838,10 +831,6 @@ model [@detre_perfusion;@alsop_recommended].
     
     tiscbf = get_tis(metadata)
 
-    if hasattr(tiscbf, '__len__'):
-        tisasl = ",".join([str(i) for i in tiscbf])
-    else:
-        tisasl = str(tiscbf)
     def pcaslorasl(metadata):
         if 'CASL' in metadata["ArterialSpinLabelingType"]:
             pcasl1 = True
@@ -921,7 +910,7 @@ In addition, CBF was also computed by Bayesian Inference for Arterial Spin Label
  perfusion image, including correction of partial volume effects [@chappell_pvc].
 """         
             basilcbf = pe.Node(BASILCBF(m0scale=M0Scale, bolus=metadata["LabelingDuration"],
-                                m0tr=metadata['RepetitionTime'], pvc=True,tis = tisasl,
+                                m0tr=metadata['RepetitionTime'], pvc=True, tis=tiscbf,
                                 pcasl = pcaslorasl(metadata = metadata)), name='basilcbf',
                        run_without_submitting=True, mem_gb=mem_gb)
             workflow.connect([


### PR DESCRIPTION
This is a potential fix for #171.

Basically, the [`tis`](https://github.com/PennLINC/aslprep/blob/b9f9ddc28d9af1e97ca31da72aa76fabaf4b68dc/aslprep/interfaces/cbf_computation.py#L724) and [`bolus`](https://github.com/PennLINC/aslprep/blob/b9f9ddc28d9af1e97ca31da72aa76fabaf4b68dc/aslprep/interfaces/cbf_computation.py#L727) inputs defined in the [`_BASILCBFInputSpec`](https://github.com/PennLINC/aslprep/blob/b9f9ddc28d9af1e97ca31da72aa76fabaf4b68dc/aslprep/interfaces/cbf_computation.py#L709) have been converted to traits of the form:

```python
taits.Either(
    traits.Float(),
    traits.List(traits.Float()),
    ...
)
```

This allows those parameters to be specified as either a scalar value (float) or a list of floats, and the trait itself will handle to conversion to a comma-separated list of numbers (string). To get a sense of what this particular change would do here is a sample script showing what happens to the resulting `oxford_asl` commands:

```python
# sample.py
import tempfile
import warnings
from pathlib import Path

warnings.filterwarnings("ignore")

import aslprep.interfaces.cbf_computation as cbfcomp


def main() -> int:
    with tempfile.TemporaryDirectory() as _tmpdir:
        tmpdir = Path(_tmpdir)

        f = create_a_real_file(tmpdir)  # so the traits.File attributes don't complain

        # BASILCBF with float --bolus and --tis
        basil1 = cbfcomp.BASILCBF(
            in_file=f,
            mask=f,
            m0scale=0.0,
            m0tr=0.0,
            tis=1.11,  # float
            bolus=4.44,  # float
            out_basename='out_base'
        )

        print('SCALARS', basil1.cmdline, sep='\n')
        assert ' --tis 1.11 ' in basil1.cmdline
        assert ' --bolus 4.44 ' in basil1.cmdline

        # BASILCBF with list[float] --bolus and --tis
        basil2 = cbfcomp.BASILCBF(
            in_file=f,
            mask=f,
            m0scale=0.0,
            m0tr=0.0,
            tis=[1.11, 2.22, 3.33],  # plain old python list
            bolus=[4.4, 5.5, 6.6],  # plain old python list
            out_basename='out_base'
        )

        print('LISTS', basil2.cmdline, sep='\n')
        assert ' --tis 1.11,2.22,3.33 ' in basil2.cmdline
        assert ' --bolus 4.4,5.5,6.6 ' in basil2.cmdline

    return 0



def create_a_real_file(d: Path) -> Path:
    existing_file = d / 't.txt'
    existing_file.write_text('')
    return existing_file


if __name__ == "__main__":
    raise SystemExit(main())
```

Assuming this branch is active and the script is saved as `sample.py`, it can be run with `python sample.py`

In a nutshell, this scripts prints the resulting `oxford_asl` command for the cases where tis/bolus is a float and a list of floats.