### PR TITLE
Correct ordering of probseg maps

### DIFF
--- a/aslprep/smriprep/data/io_spec.json
+++ b/aslprep/smriprep/data/io_spec.json
@@ -17,7 +17,7 @@
       },
       "tpms": {
         "datatype": "anat",
-        "label": [ "CSF", "GM", "WM"],
+        "label": ["GM", "WM", "CSF"],
         "suffix": "probseg"
       }
     },


### PR DESCRIPTION
Resolves #191 

Also seen in https://github.com/nipreps/smriprep/pull/214

When running aslprep with the `--anat-derivatives` flag, the wrong tissue labels are being used.