### PR TITLE
Pin looseversion

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ python_requires = >=3.7
 install_requires =
     indexed_gzip >= 0.8.8
     jinja2 < 3.1
+    looseversion == 1.0.3
     nibabel >= 3.0
     niflow-nipype1-workflows
     nipype >= 1.4


### PR DESCRIPTION
Closes None, but addresses current CI failures. The new looseversion release (1.1.2, I think) doesn't work with the current code. I'm sure it's just due to the outdated external libraries that are bundled in the repo.

## Changes proposed in this pull request
- Pin looseversion version.