### PR TITLE
Convert inversion times to a list for compatility with BASIL interface

### DIFF
--- a/aslprep/utils/misc.py
+++ b/aslprep/utils/misc.py
@@ -366,12 +366,23 @@ def compute_cbf(metadata, mask, m0file, cbffile, m0scale=1):
     return tcbf, meancbf, att
 
 
-def get_tis(metadata: "dict[str, Any]"):
-    """Determine inversion times from metadata."""
+def get_tis(metadata: "dict[str, Any]") -> list:
+    """Determine inversion times from metadata.
+
+    Parameters
+    ----------
+    metadata : :obj:`dict`
+        Dictionary of metadata associated with ASL file.
+
+    Returns
+    -------
+    :obj:`list`
+        List of PostLabelingDelay values.
+    """
     if "CASL" in metadata["ArterialSpinLabelingType"]:
-        return np.add(metadata["PostLabelingDelay"], metadata["LabelingDuration"])
+        return np.add(metadata["PostLabelingDelay"], metadata["LabelingDuration"]).tolist()
     else:
-        return np.array(metadata["PostLabelingDelay"])
+        return np.array(metadata["PostLabelingDelay"]).tolist()
 
 
 class LabelingEfficiencyNotFoundError(Exception):


### PR DESCRIPTION
Closes #196.

## Changes proposed in this pull request
- Ensure output of `get_tis` is a list, rather than a numpy array.
