### PR TITLE
Pin networkx version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@
    :alt: Test Status
 
 .. image:: https://codecov.io/gh/PennLINC/aslprep/branch/main/graph/badge.svg
-   :target: https://codecov.io/gh/PennLINC/aslprep
+   :target: https://app.codecov.io/gh/PennLINC/aslprep/tree/main
    :alt: Codecov
 
 .. image:: https://img.shields.io/badge/Nature%20Methods-10.1038%2Fs41592--022--01458--7-purple

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     indexed_gzip >= 0.8.8
     jinja2 < 3.1
     looseversion == 1.0.3
+    networkx ~= 2.8.8  # nipype needs networkx, but 3+ isn't compatible with nipype 1.8.5
     nibabel >= 3.0
     niflow-nipype1-workflows
     nipype >= 1.8.5


### PR DESCRIPTION
Closes #226.

## Changes proposed in this pull request
- Pin networkx version to 2.8.8 (<3.0.0), because 3.0.0 introduced a backwards-incompatible change that nipype version 1.8.5 doesn't work with. This fix has worked in xcp_d already (https://github.com/PennLINC/xcp_d/pull/748).