### PR TITLE
Fix deprecations for new Docker build image release

### DIFF
--- a/aslprep/interfaces/cbf_computation.py
+++ b/aslprep/interfaces/cbf_computation.py
@@ -138,7 +138,7 @@ class ExtractCBF(SimpleInterface):
 
             newm0 = fname_presuffix(self.inputs.asl_file, suffix="_m0file")
             newm0 = regmotoasl(asl=self.inputs.asl_file, m0file=m0file, m02asl=newm0)
-            m0data_smooth = smooth_image(nb.load(newm0), fwhm=self.inputs.fwhm).get_data()
+            m0data_smooth = smooth_image(nb.load(newm0), fwhm=self.inputs.fwhm).get_fdata()
             if len(m0data_smooth.shape) > 3:
                 m0dataf = mask * np.mean(m0data_smooth, axis=3)
             else:
@@ -147,7 +147,7 @@ class ExtractCBF(SimpleInterface):
         elif self.inputs.in_metadata["M0Type"] == "Included":
             modata2 = dataasl[:, :, :, m0list]
             con2 = nb.Nifti1Image(modata2, allasl.affine, allasl.header)
-            m0data_smooth = smooth_image(con2, fwhm=self.inputs.fwhm).get_data()
+            m0data_smooth = smooth_image(con2, fwhm=self.inputs.fwhm).get_fdata()
             if len(m0data_smooth.shape) > 3:
                 m0dataf = mask * np.mean(m0data_smooth, axis=3)
             else:
@@ -161,7 +161,7 @@ class ExtractCBF(SimpleInterface):
             if len(controllist) > 0:
                 control_img = dataasl[:, :, :, controllist]
                 con = nb.Nifti1Image(control_img, allasl.affine, allasl.header)
-                control_img1 = smooth_image(con, fwhm=self.inputs.fwhm).get_data()
+                control_img1 = smooth_image(con, fwhm=self.inputs.fwhm).get_fdata()
                 m0dataf = mask * np.mean(control_img1, axis=3)
             elif len(cbflist) > 0:
                 m0dataf = mask

--- a/aslprep/niworkflows/viz/utils.py
+++ b/aslprep/niworkflows/viz/utils.py
@@ -526,7 +526,7 @@ def plot_melodic_components(
                 "Repetition time units not specified - assuming seconds"
             )
 
-    from nilearn.input_data import NiftiMasker
+    from nilearn.maskers import NiftiMasker
     from nilearn.plotting import cm
 
     if not report_mask:

--- a/aslprep/utils/misc.py
+++ b/aslprep/utils/misc.py
@@ -886,8 +886,8 @@ def parcellate_cbf(roi_file, roi_label, cbfmap):
 
     TODO: Replace with NiftiLabelsMasker.
     """
-    data = nb.load(cbfmap).get_data()
-    roi = nb.load(roi_file).get_data()
+    data = nb.load(cbfmap).get_fdata()
+    roi = nb.load(roi_file).get_fdata()
     roi_labels = np.loadtxt(roi_label)
     if data.shape != roi.shape:
         raise ValueError("Image-shapes do not match")


### PR DESCRIPTION
Closes None.

## Changes proposed in this pull request

- Replace calls to `img.get_data()` with `img.get_fdata()`.