### PR TITLE
Index aslcontext rows with "cbf", not "CBF"

### DIFF
--- a/aslprep/interfaces/cbf_computation.py
+++ b/aslprep/interfaces/cbf_computation.py
@@ -153,7 +153,7 @@ class ExtractCBF(SimpleInterface):
         label_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "label"]
         m0_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "m0scan"]
         deltam_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "deltam"]
-        cbf_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "CBF"]
+        cbf_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "cbf"]
 
         # extract m0 file and register it to ASL if separate
         if metadata["M0Type"] == "Separate":
@@ -315,7 +315,7 @@ class ExtractCBForDeltaM(SimpleInterface):
         control_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "control"]
         label_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "label"]
         deltam_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "deltam"]
-        cbf_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "CBF"]
+        cbf_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "cbf"]
 
         if self.inputs.file_type == "d":
             if len(control_volume_idx) > 0:

--- a/aslprep/interfaces/ge.py
+++ b/aslprep/interfaces/ge.py
@@ -62,7 +62,7 @@ class GeReferenceFile(SimpleInterface):
         vol_types = aslcontext_df["volume_type"].tolist()
         control_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "control"]
         deltam_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "deltam"]
-        cbf_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "CBF"]
+        cbf_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "cbf"]
 
         asl_img = nb.load(self.inputs.in_file)
         asl_data = asl_img.get_fdata()

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -506,7 +506,7 @@ model [@detre_perfusion_1992;@alsop_recommended_2015].
 
     vol_types = aslcontext_df["volume_type"].tolist()
     deltam_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "deltam"]
-    cbf_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "CBF"]
+    cbf_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "cbf"]
     control_volume_idx = [i for i, vol_type in enumerate(vol_types) if vol_type == "control"]
 
     tiscbf = get_tis(metadata)


### PR DESCRIPTION
Closes None.

## Changes proposed in this pull request

- In sections where the aslcontext file is indexed to find CBF volumes, the code originally looked for "CBF", but the BIDS spec only allows "cbf".