### PR TITLE
Use same TPM threshold for GE and non-GE data

### DIFF
--- a/aslprep/interfaces/cbf_computation.py
+++ b/aslprep/interfaces/cbf_computation.py
@@ -596,7 +596,7 @@ class _ScoreAndScrubCBFInputSpec(BaseInterfaceInputSpec):
         default_value=0.7,
         usedefault=True,
         mandatory=False,
-        desc="Tissue probability threshold.",
+        desc="Tissue probability threshold for binarizing GM, WM, and CSF masks.",
     )
     wavelet_function = traits.Str(
         default_value="huber",

--- a/aslprep/interfaces/qc.py
+++ b/aslprep/interfaces/qc.py
@@ -49,7 +49,12 @@ class _ComputeCBFQCInputSpec(BaseInterfaceInputSpec):
     t1w_mask = File(exists=True, mandatory=True, desc="T1w mask in native space")
     asl_mask_std = File(exists=True, mandatory=False, desc="ASL mask in standard space")
     template_mask = File(exists=True, mandatory=False, desc="template mask or image")
-    tpm_threshold = traits.Float(desc="Typically 0.7 for non-GE data and 0.8 for GE data.")
+    tpm_threshold = traits.Float(
+        default_value=0.7,
+        usedefault=True,
+        mandatory=False,
+        desc="Tissue probability threshold for binarizing GM, WM, and CSF masks.",
+    )
     # Non-GE-only inputs
     confounds_file = File(
         exists=True,

--- a/aslprep/utils/qc.py
+++ b/aslprep/utils/qc.py
@@ -90,7 +90,7 @@ def coverage(input1, input2):
     return intsec / smallv
 
 
-def average_cbf_by_tissue(cbf, gm, wm, csf, thresh=0.7):
+def average_cbf_by_tissue(cbf, gm, wm, csf, thresh):
     """Compute mean GM, WM, and CSF CBF values.
 
     Parameters
@@ -118,7 +118,7 @@ def average_cbf_by_tissue(cbf, gm, wm, csf, thresh=0.7):
     return mean_tissue_cbfs
 
 
-def compute_qei(gm, wm, csf, img, thresh=0.8):
+def compute_qei(gm, wm, csf, img, thresh):
     """Compute quality evaluation index (QEI) of CBF.
 
     The QEI is based on :footcite:t:`dolui2017automated`.
@@ -175,7 +175,7 @@ def compute_qei(gm, wm, csf, img, thresh=0.8):
     return gmean(Q)
 
 
-def negativevoxel(cbf, gm, thresh=0.7):
+def negativevoxel(cbf, gm, thresh):
     """Compute percentage of negative voxels within grey matter mask."""
     gm = nb.load(gm).get_fdata()
     cbf = nb.load(cbf).get_fdata()

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -622,7 +622,7 @@ CBF with structural tissues probability maps [@dolui2017structural;@dolui2016scr
         score_and_scrub_cbf = pe.Node(
             ScoreAndScrubCBF(tpm_threshold=0.7, wavelet_function="huber"),
             mem_gb=mem_gb,
-            name="scorescrub",
+            name="score_and_scrub_cbf",
             run_without_submitting=True,
         )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,6 @@ doc =
 docs =
     %(doc)s
 tests =
-    codecov
     coverage
     pytest
     pytest-cov


### PR DESCRIPTION
Closes #260.

## Changes proposed in this pull request

- The use of different TPM thresholds for GE (0.8) and non-GE (0.7) data was most likely a bug, so this PR uses 0.7 across both workflows.