### PR TITLE
Improve plots

### DIFF
--- a/aslprep/data/reports-spec.yml
+++ b/aslprep/data/reports-spec.yml
@@ -11,19 +11,20 @@ sections:
       extension: [.html]
       suffix: T1w
   - bids: {datatype: figures, suffix: dseg}
-    caption: This panel shows the template T1-weighted image (if several T1w images
-      were found), with contours delineating the detected brain mask and brain tissue
-      segmentations.
+    caption: |
+      This panel shows the template T1-weighted image (if several T1w images were found),
+      with contours delineating the detected brain mask and brain tissue segmentations.
     subtitle: Brain mask and brain tissue segmentation of the T1w
   - bids: {datatype: figures, space: .*, suffix: T1w, regex_search: True}
     caption: Spatial normalization of the T1w image to the <code>{space}</code> template.
-    description: Results of nonlinear alignment of the T1w reference one or more template
-      space(s). Hover on the panels with the mouse pointer to transition between both
-      spaces.
+    description: |
+      Results of nonlinear alignment of the T1w reference one or more template space(s).
+      Hover on the panels with the mouse pointer to transition between both spaces.
     static: false
     subtitle: Spatial normalization of the anatomical T1w reference
   - bids: {datatype: figures, desc: reconall, suffix: T1w}
-    caption: Surfaces (white and pial) reconstructed with FreeSurfer (<code>recon-all</code>)
+    caption: |
+      Surfaces (white and pial) reconstructed with FreeSurfer (<code>recon-all</code>)
       overlaid on the participant's T1w template.
     subtitle: Surface reconstruction
 - name:  Arterial Spin Labelling
@@ -32,7 +33,8 @@ sections:
   - bids: {datatype: figures, desc: summary, suffix: asl}
   - bids: {datatype: figures, desc: validation, suffix: asl}
   - bids: {datatype: figures, desc: fieldmap, suffix: bold}
-    caption: The estimated fieldmap was aligned to the corresponding ASL reference
+    caption: |
+      The estimated fieldmap was aligned to the corresponding ASL reference
       with a rigid-registration process of the magintude part of the fieldmap,
       using <code>antsRegistration</code>.
       Overlaid on top of the co-registration results, the displacements along the
@@ -43,82 +45,123 @@ sections:
     static: false
     subtitle: Estimated fieldmap and alignment to the corresponding ASL reference
   - bids: {datatype: figures, desc: sdc, suffix: bold}
-    caption: Results of performing susceptibility distortion correction (SDC) on the
-      ASL
+    caption: |
+      Results of performing susceptibility distortion correction (SDC) on the ASL.
     static: false
     subtitle: Susceptibility distortion correction
   - bids: {datatype: figures, desc: forcedsyn, suffix: bold}
-    caption: The dataset contained some fieldmap information, but the argument <code>--force-syn</code>
-      was used. The higher-priority SDC method was used. Here, we show the results
-      of performing SyN-based SDC on the EPI for comparison.
+    caption: |
+      The dataset contained some fieldmap information, but the argument <code>--force-syn</code>
+      was used. The higher-priority SDC method was used.
+      Here, we show the results of performing SyN-based SDC on the EPI for comparison.
     static: false
     subtitle: Experimental fieldmap-less susceptibility distortion correction
   - bids: {datatype: figures, desc: flirtnobbr, suffix: asl}
-    caption: FSL <code>flirt</code> was used to generate transformations from ASL
-      space to T1 Space - BBR refinement rejected. Note that Nearest Neighbor interpolation
-      is used in the reportlets in order to highlight potential spin-history and other
-      artifacts, whereas final images are resampled using Lanczos interpolation.
+    caption: |
+      FSL <code>flirt</code> was used to generate transformations from ASL
+      space to T1 Space - BBR refinement rejected.
+      Note that Nearest Neighbor interpolation is used in the reportlets in order to highlight
+      potential spin-history and other artifacts,
+      whereas final images are resampled using Lanczos interpolation.
     static: false
-    subtitle: Alignment of asl and anatomical MRI data (volume based)
+    subtitle: Alignment of ASL and anatomical MRI data (volume based)
   - bids: {datatype: figures, desc: coreg, suffix: asl}
-    caption: <code>mri_coreg</code> (FreeSurfer) was used to generate transformations
-      from EPI space to T1 Space - <code>bbregister</code> refinement rejected. Note
-      that Nearest Neighbor interpolation is used in the reportlets in order to highlight
-      potential spin-history and other artifacts, whereas final images are resampled
-      using Lanczos interpolation.
+    caption: |
+      <code>mri_coreg</code> (FreeSurfer) was used to generate transformations
+      from EPI space to T1 Space - <code>bbregister</code> refinement rejected.
+      Note that Nearest Neighbor interpolation is used in the reportlets in order to highlight
+      potential spin-history and other artifacts,
+      whereas final images are resampled using Lanczos interpolation.
     static: false
-    subtitle: Alignment of asl and anatomical MRI data (volume based)
+    subtitle: Alignment of ASL and anatomical MRI data (volume based)
   - bids: {datatype: figures, desc: flirtbbr, suffix: asl}
-    caption: FSL <code>flirt</code> was used to generate transformations from EPI-space
-      to T1w-space - The white matter mask calculated with FSL <code>fast</code> (brain
-      tissue segmentation) was used for BBR. Note that Nearest Neighbor interpolation
-      is used in the reportlets in order to highlight potential spin-history and other
-      artifacts, whereas final images are resampled using Lanczos interpolation.
+    caption: |
+      FSL <code>flirt</code> was used to generate transformations from EPI-space to T1w-space -
+      The white matter mask calculated with FSL <code>fast</code>
+      (brain tissue segmentation) was used for BBR.
+      Note that Nearest Neighbor interpolation is used in the reportlets in order to
+      highlight potential spin-history and other artifacts,
+      whereas final images are resampled using Lanczos interpolation.
     static: false
-    subtitle: Alignment of asl and anatomical MRI data (surface driven)
+    subtitle: Alignment of ASL and anatomical MRI data (surface driven)
   - bids: {datatype: figures, desc: bbregister, suffix: asl}
-    caption: <code>bbregister</code> was used to generate transformations from EPI-space
-      to T1w-space. Note that Nearest Neighbor interpolation is used in the reportlets
-      in order to highlight potential spin-history and other artifacts, whereas final
-      images are resampled using Lanczos interpolation.
+    caption: |
+      <code>bbregister</code> was used to generate transformations from EPI-space to T1w-space.
+      Note that Nearest Neighbor interpolation is used in the reportlets in order to highlight
+      potential spin-history and other artifacts,
+      whereas final images are resampled using Lanczos interpolation.
     static: false
-    subtitle: Alignment of asl and anatomical MRI data (surface driven)
+    subtitle: Alignment of ASL and anatomical MRI data (surface driven)
   - bids: {datatype: figures, desc: carpetplot, suffix: asl}
-    caption: Summary statistics are plotted, which may reveal trends or artifacts
-      in the asl data. DVARS and FD show the standardized DVARS
-      and framewise-displacement measures for each time point. A carpet plot
-      shows the time series for all voxels within the brain mask. Voxels are grouped
-      into cortical (blue), and subcortical (orange) gray matter, cerebellum (green)
-      and white matter and CSF (red), indicated by the color map on the left-hand
-      side.
+    caption: |
+      Summary statistics are plotted, which may reveal trends or artifacts in the ASL data.
+      DVARS and FD show the standardized DVARS and framewise-displacement measures for each time point.
+      A carpet plot shows the time series for all voxels within the brain mask.
+      Voxels are grouped into cortical (blue), and subcortical (orange) gray matter, cerebellum (green)
+      and white matter and CSF (red), indicated by the color map on the left-hand side.
     subtitle: ASL Summary
   - bids: {datatype: figures, desc: cbftsplot, suffix: asl}
-    caption: This carpet plot shows the time series for all voxels within the brain mask for
-      CBF. Voxels are grouped into cortical (blue), and subcortical
-      (orange) gray matter, cerebellum (green), white matter and CSF (red), indicated by the
-      color map on the left-hand side. The score Index with value greater than zero indicates
-      which volume(s) are removed by SCORE.
+    caption: |
+      This carpet plot shows the time series for all voxels within the brain mask for CBF.
+      Voxels are grouped into cortical (blue), and subcortical (orange) gray matter,
+      cerebellum (green), white matter and CSF (red), indicated by the color map on the left-hand side.
+      The SCORE index with values greater than zero indicates which volume(s) are removed by SCORE.
     subtitle: CBF Summary
   - bids: {datatype: figures, desc: cbfplot, suffix: asl}
-    caption: The maps plot cerebral blood flow (CBF) for basic CBF.
-       The unit is mL/100 g/min
+    caption: |
+      The maps plot cerebral blood flow (CBF) for basic CBF.
+      The unit is mL/100 g/min.
     subtitle: CBF maps
+  - bids: {datatype: figures, desc: cbfByTissueType, suffix: asl}
+    caption: |
+      The maps plot the distribution of cerebral blood flow (CBF) values for the basic output,
+      separated by tissue type.
+      The unit is mL/100 g/min.
+    subtitle: Mean CBF by Tissue Type
   - bids: {datatype: figures, desc: scoreplot, suffix: asl}
-    caption: The maps plot cerebral blood flow (CBF) for SCORE-corrected CBF.
-       The unit is mL/100 g/min
+    caption: |
+      The maps plot cerebral blood flow (CBF) for SCORE-corrected CBF.
+      The unit is mL/100 g/min
     subtitle: SCORE CBF maps
+  - bids: {datatype: figures, desc: scoreByTissueType, suffix: asl}
+    caption: |
+      The maps plot the distribution of cerebral blood flow (CBF) values for the SCORE output,
+      separated by tissue type.
+      The unit is mL/100 g/min.
+    subtitle: SCORE CBF by Tissue Type
   - bids: {datatype: figures, desc: scrubplot, suffix: asl}
-    caption: The maps plot cerebral blood flow (CBF) for SCRUB-corrected CBF.
-       The unit is mL/100 g/min
+    caption: |
+      The maps plot cerebral blood flow (CBF) for SCRUB-corrected CBF.
+      The unit is mL/100 g/min.
     subtitle: SCRUB CBF maps
+  - bids: {datatype: figures, desc: scrubByTissueType, suffix: asl}
+    caption: |
+      The maps plot the distribution of cerebral blood flow (CBF) values for the SCRUB output,
+      separated by tissue type.
+      The unit is mL/100 g/min.
+    subtitle: SCRUB CBF by Tissue Type
   - bids: {datatype: figures, desc: basilplot, suffix: asl}
-    caption: The maps plot cerebral blood flow (CBF) for BASIL-estimated CBF.
-       The unit is mL/100 g/min
+    caption: |
+      The maps plot cerebral blood flow (CBF) for BASIL-estimated CBF.
+      The unit is mL/100 g/min.
     subtitle: BASIL CBF maps
+  - bids: {datatype: figures, desc: basilByTissueType, suffix: asl}
+    caption: |
+      The maps plot the distribution of cerebral blood flow (CBF) values for the BASIL output,
+      separated by tissue type.
+      The unit is mL/100 g/min.
+    subtitle: BASIL CBF by Tissue Type
   - bids: {datatype: figures, desc: pvcplot, suffix: asl}
-    caption: The maps plot cerebral blood flow (CBF) for partial volume-corrected CBF.
-       The unit is mL/100 g/min
+    caption: |
+      The maps plot cerebral blood flow (CBF) for partial volume-corrected CBF.
+      The unit is mL/100 g/min
     subtitle: PVC CBF maps
+  - bids: {datatype: figures, desc: pvcByTissueType, suffix: asl}
+    caption: |
+      The maps plot the distribution of cerebral blood flow (CBF) values for the
+      BASIL partial volume-corrected output, separated by tissue type.
+      The unit is mL/100 g/min.
+    subtitle: PVC CBF by Tissue Type
 - name: About
   reportlets:
   - bids: {datatype: figures, desc: about, suffix: T1w}

--- a/aslprep/interfaces/plotting.py
+++ b/aslprep/interfaces/plotting.py
@@ -25,7 +25,9 @@ class _ASLSummaryInputSpec(BaseInterfaceInputSpec):
         traits.Tuple(traits.Str, traits.Either(None, traits.Str), traits.Either(None, traits.Str)),
     )
     confounds_list = traits.List(
-        str_or_tuple, minlen=1, desc="list of headers to extract from the confounds_file"
+        str_or_tuple,
+        minlen=1,
+        desc="list of headers to extract from the confounds_file",
     )
     tr = traits.Either(None, traits.Float, usedefault=True, desc="the repetition time")
 
@@ -45,7 +47,10 @@ class ASLSummary(SimpleInterface):
 
     def _run_interface(self, runtime):
         self._results["out_file"] = fname_presuffix(
-            self.inputs.in_func, suffix="_aslplot.svg", use_ext=False, newpath=runtime.cwd
+            self.inputs.in_func,
+            suffix="_aslplot.svg",
+            use_ext=False,
+            newpath=runtime.cwd,
         )
 
         dataframe = pd.read_csv(
@@ -151,7 +156,10 @@ class CBFtsSummary(SimpleInterface):
 
     def _run_interface(self, runtime):
         self._results["out_file"] = fname_presuffix(
-            self.inputs.cbf_ts, suffix="_cbfcarpetplot.svg", use_ext=False, newpath=runtime.cwd
+            self.inputs.cbf_ts,
+            suffix="_cbfcarpetplot.svg",
+            use_ext=False,
+            newpath=runtime.cwd,
         )
         fig = CBFtsPlot(
             cbf_file=self.inputs.cbf_ts,
@@ -199,7 +207,7 @@ class CBFByTissueTypePlot(SimpleInterface):
             )
             tissue_type_vals = masking.apply_mask(self.inputs.cbf, mask_img)
             df = pd.DataFrame(
-                columns=["CBF (mL/100 g/min)", "Tissue Type"],
+                columns=["CBF\n(mL/100 g/min)", "Tissue Type"],
                 data=list(
                     map(list, zip(*[tissue_type_vals, [tissue_type] * tissue_type_vals.size]))
                 ),
@@ -209,20 +217,19 @@ class CBFByTissueTypePlot(SimpleInterface):
         df = pd.concat(dfs, axis=0)
 
         # Create the plot
-        with sns.axes_style("whitegrid"), sns.plotting_context(font_scale=2):
+        with sns.axes_style("whitegrid"), sns.plotting_context(font_scale=3):
             fig, ax = plt.subplots(figsize=(16, 8))
             sns.despine(ax=ax, bottom=True, left=True)
-
-            # Plot the orbital period with horizontal boxes
             sns.boxenplot(
                 x="Tissue Type",
-                y="CBF (mL/100 g/min)",
+                y="CBF\n(mL/100 g/min)",
                 data=df,
                 width=0.6,
                 showfliers=True,
                 palette={"GM": "#1b60a5", "WM": "#2da467", "CSF": "#9d8f25"},
                 ax=ax,
             )
+            fig.tight_layout()
             fig.savefig(self._results["out_file"])
 
         return runtime

--- a/aslprep/interfaces/plotting.py
+++ b/aslprep/interfaces/plotting.py
@@ -116,7 +116,10 @@ class CBFSummary(SimpleInterface):
 
     def _run_interface(self, runtime):
         self._results["out_file"] = fname_presuffix(
-            self.inputs.cbf, suffix="_cbfplot.svg", use_ext=False, newpath=runtime.cwd
+            self.inputs.cbf,
+            suffix="_cbfplot.svg",
+            use_ext=False,
+            newpath=runtime.cwd,
         )
         CBFPlot(
             cbf=self.inputs.cbf,
@@ -125,7 +128,6 @@ class CBFSummary(SimpleInterface):
             vmax=self.inputs.vmax,
             outfile=self._results["out_file"],
         ).plot()
-        # fig.savefig(self._results['out_file'], bbox_inches='tight')
         return runtime
 
 

--- a/aslprep/interfaces/reports.py
+++ b/aslprep/interfaces/reports.py
@@ -144,17 +144,31 @@ class SubjectSummary(SummaryInterface):
 
 class _FunctionalSummaryInputSpec(BaseInterfaceInputSpec):
     distortion_correction = traits.Str(
-        desc="Susceptibility distortion correction method", mandatory=True
+        desc="Susceptibility distortion correction method",
+        mandatory=True,
     )
     pe_direction = traits.Enum(
-        None, "i", "i-", "j", "j-", mandatory=True, desc="Phase-encoding direction detected"
+        None,
+        "i",
+        "i-",
+        "j",
+        "j-",
+        mandatory=True,
+        desc="Phase-encoding direction detected",
     )
     registration = traits.Enum(
-        "FSL", "FreeSurfer", mandatory=True, desc="Functional/anatomical registration method"
+        "FSL",
+        "FreeSurfer",
+        mandatory=True,
+        desc="Functional/anatomical registration method",
     )
     fallback = traits.Bool(desc="Boundary-based registration rejected")
     registration_dof = traits.Enum(
-        6, 9, 12, desc="Registration degrees of freedom", mandatory=True
+        6,
+        9,
+        12,
+        desc="Registration degrees of freedom",
+        mandatory=True,
     )
     registration_init = traits.Enum(
         "register",

--- a/aslprep/niworkflows/interfaces/masks.py
+++ b/aslprep/niworkflows/interfaces/masks.py
@@ -298,7 +298,7 @@ class ROIsPlot(nrc.ReportingInterface):
     input_spec = _ROIsPlotInputSpecRPT
 
     def _generate_report(self):
-        from aslprep.niworkflows.viz.utils import plot_segs, compose_view
+        from niworkflows.viz.utils import plot_segs, compose_view
 
         seg_files = self.inputs.in_rois
         mask_file = None if not isdefined(self.inputs.in_mask) else self.inputs.in_mask

--- a/aslprep/niworkflows/interfaces/report_base.py
+++ b/aslprep/niworkflows/interfaces/report_base.py
@@ -7,7 +7,7 @@ from nilearn.image import threshold_img, load_img
 from nipype.interfaces.base import File, traits
 from nipype.interfaces.mixins import reporting
 from .. import NIWORKFLOWS_LOG
-from ..viz.utils import cuts_from_bbox, compose_view
+from niworkflows.viz.utils import cuts_from_bbox, compose_view
 
 
 class _SVGReportCapableInputSpec(reporting.ReportCapableInputSpec):

--- a/aslprep/sdcflows/interfaces/reportlets.py
+++ b/aslprep/sdcflows/interfaces/reportlets.py
@@ -4,7 +4,7 @@
 import numpy as np
 from nilearn.image import threshold_img, load_img
 from ...niworkflows import NIWORKFLOWS_LOG
-from ...niworkflows.viz.utils import cuts_from_bbox, compose_view
+from niworkflows.viz.utils import cuts_from_bbox, compose_view
 from nipype.interfaces.base import File, isdefined, traits
 from nipype.interfaces.mixins import reporting
 

--- a/aslprep/utils/misc.py
+++ b/aslprep/utils/misc.py
@@ -771,3 +771,10 @@ def estimate_labeling_efficiency(metadata):
             labeleff *= BS_PULSE_EFF ** metadata.get("BackgroundSuppressionNumberPulses", 1)
 
     return labeleff
+
+
+def get_template_str(template, kwargs):
+    """Get template from templateflow, as a string."""
+    from templateflow.api import get as get_template
+
+    return str(get_template(template, **kwargs))

--- a/aslprep/utils/plotting.py
+++ b/aslprep/utils/plotting.py
@@ -8,7 +8,7 @@ from lxml import etree
 from matplotlib import gridspec as mgs
 from nilearn import plotting
 from nilearn.image import threshold_img
-from niworkflows.viz.plots import _get_tr, confoundplot, plot_carpet, spikesplot
+from niworkflows.interfaces.plotting import _get_tr
 from niworkflows.viz.utils import (
     _3d_in_file,
     compose_view,
@@ -20,6 +20,7 @@ from seaborn import color_palette
 from svgutils.transform import SVGFigure
 
 from aslprep.niworkflows import NIWORKFLOWS_LOG
+from aslprep.niworkflows.viz.plots import confoundplot, plot_carpet, spikesplot
 
 
 class ASLPlot:

--- a/aslprep/utils/plotting.py
+++ b/aslprep/utils/plotting.py
@@ -236,7 +236,7 @@ def plot_stat_map(
         display = plotting.plot_img(
             img=cbf,
             bg_img=ref_vol,
-            resampling_interpolation="continuous",
+            resampling_interpolation="nearest",
             display_mode=mode,
             cut_coords=cuts[mode],
             vmin=-20,

--- a/aslprep/utils/plotting.py
+++ b/aslprep/utils/plotting.py
@@ -234,7 +234,7 @@ def plot_stat_map(
     # Plot each cut axis
     for i, mode in enumerate(list(order)):
         display = plotting.plot_stat_map(
-            img=cbf,
+            stat_map_img=cbf,
             bg_img=ref_vol,
             resampling_interpolation="nearest",
             display_mode=mode,

--- a/aslprep/utils/plotting.py
+++ b/aslprep/utils/plotting.py
@@ -212,7 +212,7 @@ def plot_stat_map(
     ref_vol,
     plot_params=None,
     order=("z", "x", "y"),
-    vmax=90,
+    vmax=100,
     estimate_brightness=False,
     label=None,
     compress="auto",

--- a/aslprep/utils/plotting.py
+++ b/aslprep/utils/plotting.py
@@ -233,17 +233,17 @@ def plot_stat_map(
 
     # Plot each cut axis
     for i, mode in enumerate(list(order)):
-        display = plotting.plot_img(
+        display = plotting.plot_stat_map(
             img=cbf,
             bg_img=ref_vol,
             resampling_interpolation="nearest",
             display_mode=mode,
             cut_coords=cuts[mode],
-            vmin=-20,
             vmax=vmax,
             threshold=0.02,
             draw_cross=False,
             colorbar=True,
+            symmetric_cbar=False,
             cmap="coolwarm",
             title=label if i == 0 else None,
         )

--- a/aslprep/utils/plotting.py
+++ b/aslprep/utils/plotting.py
@@ -233,17 +233,17 @@ def plot_stat_map(
 
     # Plot each cut axis
     for i, mode in enumerate(list(order)):
-        display = plotting.plot_stat_map(
-            stat_map_img=cbf,
+        display = plotting.plot_img(
+            img=cbf,
             bg_img=ref_vol,
             resampling_interpolation="continuous",
             display_mode=mode,
             cut_coords=cuts[mode],
+            vmin=-20,
             vmax=vmax,
             threshold=0.02,
             draw_cross=False,
             colorbar=True,
-            symmetric_cbar=False,
             cmap="coolwarm",
             title=label if i == 0 else None,
         )

--- a/aslprep/utils/plotting.py
+++ b/aslprep/utils/plotting.py
@@ -8,6 +8,7 @@ from lxml import etree
 from matplotlib import gridspec as mgs
 from nilearn import plotting
 from nilearn.image import threshold_img
+from niworkflows.viz.plots import _get_tr, confoundplot, plot_carpet, spikesplot
 from niworkflows.viz.utils import (
     _3d_in_file,
     compose_view,
@@ -19,7 +20,6 @@ from seaborn import color_palette
 from svgutils.transform import SVGFigure
 
 from aslprep.niworkflows import NIWORKFLOWS_LOG
-from aslprep.niworkflows.viz.plots import _get_tr, confoundplot, plot_carpet, spikesplot
 
 
 class ASLPlot:

--- a/aslprep/utils/plotting.py
+++ b/aslprep/utils/plotting.py
@@ -7,7 +7,7 @@ import seaborn as sns
 from lxml import etree
 from matplotlib import gridspec as mgs
 from nilearn.image import threshold_img
-from nilearn.plotting import plot_stat_map
+from nilearn import plotting
 from seaborn import color_palette
 from svgutils.transform import SVGFigure
 
@@ -197,13 +197,16 @@ class CBFPlot(object):
 
     def plot(self):
         """Generate the plot."""
-        statfile = plotstatsimg(
-            cbf=self.cbf, ref_vol=self.ref_vol, vmax=self.vmax, label=self.label
+        statfile = plot_stat_map(
+            cbf=self.cbf,
+            ref_vol=self.ref_vol,
+            vmax=self.vmax,
+            label=self.label,
         )
         compose_view(bg_svgs=statfile, fg_svgs=None, out_file=self.outfile)
 
 
-def plotstatsimg(
+def plot_stat_map(
     cbf,
     ref_vol,
     plot_params=None,
@@ -229,22 +232,19 @@ def plotstatsimg(
 
     # Plot each cut axis
     for i, mode in enumerate(list(order)):
-        plot_params["display_mode"] = mode
-        plot_params["cut_coords"] = cuts[mode]
-        plot_params["draw_cross"] = False
-        plot_params["symmetric_cbar"] = True
-        plot_params["vmax"] = vmax
-        plot_params["threshold"] = 0.02
-        plot_params["colorbar"] = True
-        plot_params["cmap"] = "coolwarm"
-        if i == 0:
-            plot_params["title"] = label
-            plot_params["colorbar"] = True
-        else:
-            plot_params["title"] = None
-
-        display = plot_stat_map(
-            stat_map_img=cbf, bg_img=ref_vol, resampling_interpolation="nearest", **plot_params
+        display = plotting.plot_stat_map(
+            stat_map_img=cbf,
+            bg_img=ref_vol,
+            resampling_interpolation="continuous",
+            display_mode=mode,
+            cut_coords=cuts[mode],
+            vmax=vmax,
+            threshold=0.02,
+            draw_cross=False,
+            colorbar=True,
+            symmetric_cbar=False,
+            cmap="coolwarm",
+            title=label if i == 0 else None,
         )
         svg = extract_svg(display, compress=compress)
         display.close()

--- a/aslprep/utils/plotting.py
+++ b/aslprep/utils/plotting.py
@@ -13,7 +13,7 @@ from svgutils.transform import SVGFigure
 
 from aslprep.niworkflows import NIWORKFLOWS_LOG
 from aslprep.niworkflows.viz.plots import _get_tr, confoundplot, plot_carpet, spikesplot
-from aslprep.niworkflows.viz.utils import (
+from niworkflows.viz.utils import (
     _3d_in_file,
     compose_view,
     cuts_from_bbox,

--- a/aslprep/utils/plotting.py
+++ b/aslprep/utils/plotting.py
@@ -6,13 +6,8 @@ import pandas as pd
 import seaborn as sns
 from lxml import etree
 from matplotlib import gridspec as mgs
-from nilearn.image import threshold_img
 from nilearn import plotting
-from seaborn import color_palette
-from svgutils.transform import SVGFigure
-
-from aslprep.niworkflows import NIWORKFLOWS_LOG
-from aslprep.niworkflows.viz.plots import _get_tr, confoundplot, plot_carpet, spikesplot
+from nilearn.image import threshold_img
 from niworkflows.viz.utils import (
     _3d_in_file,
     compose_view,
@@ -20,6 +15,11 @@ from niworkflows.viz.utils import (
     extract_svg,
     robust_set_limits,
 )
+from seaborn import color_palette
+from svgutils.transform import SVGFigure
+
+from aslprep.niworkflows import NIWORKFLOWS_LOG
+from aslprep.niworkflows.viz.plots import _get_tr, confoundplot, plot_carpet, spikesplot
 
 
 class ASLPlot:

--- a/aslprep/workflows/asl/gecbf.py
+++ b/aslprep/workflows/asl/gecbf.py
@@ -17,7 +17,7 @@ from aslprep.utils.misc import _create_mem_gb, _get_wf_name
 from aslprep.workflows.asl.cbf import init_compute_cbf_ge_wf, init_parcellate_cbf_wf
 from aslprep.workflows.asl.ge_utils import init_asl_reference_ge_wf, init_asl_reg_ge_wf
 from aslprep.workflows.asl.outputs import init_asl_derivatives_wf
-from aslprep.workflows.asl.plotting import init_gecbfplot_wf
+from aslprep.workflows.asl.plotting import init_plot_cbf_wf
 from aslprep.workflows.asl.qc import init_compute_cbf_qc_wf
 from aslprep.workflows.asl.registration import init_asl_t1_trans_wf
 from aslprep.workflows.asl.resampling import init_asl_std_trans_wf
@@ -579,27 +579,6 @@ effects of other kernels [@lanczos].
             ])
             # fmt:on
 
-    # Plot CBF outputs.
-    plot_cbf_wf = init_gecbfplot_wf(
-        basil=basil,
-        name="plot_cbf_wf",
-    )
-
-    for cbf_deriv in mean_cbf_derivs:
-        # fmt:off
-        workflow.connect([
-            (compute_cbf_wf, plot_cbf_wf, [
-                (f"outputnode.{cbf_deriv}", f"inputnode.{cbf_deriv}"),
-            ]),
-        ])
-        # fmt:on
-
-    # fmt:off
-    workflow.connect([
-        (asl_reference_wf, plot_cbf_wf, [("outputnode.ref_image_brain", "inputnode.aslref")]),
-    ])
-    # fmt:on
-
     # xform to 'MNI152NLin2009cAsym' is always computed, so this should always be available.
     select_xform_MNI152NLin2009cAsym_to_t1w = pe.Node(
         KeySelect(fields=["template_to_anat_xfm"], key="MNI152NLin2009cAsym"),
@@ -615,6 +594,38 @@ effects of other kernels [@lanczos].
         ]),
     ])
     # fmt:on
+
+    # Plot CBF outputs.
+    plot_cbf_wf = init_plot_cbf_wf(
+        metadata=metadata,
+        plot_timeseries=False,
+        scorescrub=scorescrub,
+        basil=basil,
+        name="plot_cbf_wf",
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, plot_cbf_wf, [("t1w_dseg", "inputnode.t1w_dseg")]),
+        (select_xform_MNI152NLin2009cAsym_to_t1w, plot_cbf_wf, [
+            ("template_to_anat_xfm", "inputnode.template_to_anat_xfm"),
+        ]),
+        (asl_reference_wf, plot_cbf_wf, [("outputnode.ref_image_brain", "inputnode.aslref")]),
+        (asl_reg_wf, plot_cbf_wf, [
+            ("outputnode.anat_to_aslref_xfm", "inputnode.anat_to_aslref_xfm"),
+        ]),
+        (refine_mask, plot_cbf_wf, [("out_mask", "inputnode.asl_mask")]),
+    ])
+    # fmt:on
+
+    for cbf_deriv in mean_cbf_derivs:
+        # fmt:off
+        workflow.connect([
+            (compute_cbf_wf, plot_cbf_wf, [
+                (f"outputnode.{cbf_deriv}", f"inputnode.{cbf_deriv}"),
+            ]),
+        ])
+        # fmt:on
 
     parcellate_cbf_wf = init_parcellate_cbf_wf(
         scorescrub=scorescrub,

--- a/aslprep/workflows/asl/plotting.py
+++ b/aslprep/workflows/asl/plotting.py
@@ -3,20 +3,21 @@
 """Workflows for plotting ASLPrep derivatives."""
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
-from templateflow.api import get as get_template
 
 from aslprep import config
 from aslprep.interfaces import DerivativesDataSink
 from aslprep.interfaces.ants import ApplyTransforms
-from aslprep.interfaces.plotting import CBFSummary, CBFtsSummary
+from aslprep.interfaces.plotting import CBFByTissueTypePlot, CBFSummary, CBFtsSummary
 from aslprep.niworkflows.engine.workflows import LiterateWorkflow as Workflow
+from aslprep.utils.misc import get_template_str
 
 
-def init_cbfplot_wf(
+def init_plot_cbf_wf(
     metadata,
+    plot_timeseries=True,
     scorescrub=False,
     basil=False,
-    name="cbf_plot",
+    name="plot_cbf_wf",
 ):
     """Plot CBF results.
 
@@ -25,9 +26,9 @@ def init_cbfplot_wf(
             :graph2use: orig
             :simple_form: yes
 
-            from aslprep.workflows.asl.plotting import init_cbfplot_wf
+            from aslprep.workflows.asl.plotting import init_plot_cbf_wf
 
-            wf = init_cbfplot_wf(
+            wf = init_plot_cbf_wf(
                 metadata={"RepetitionTimePreparation": 4},
             )
     """
@@ -38,14 +39,15 @@ def init_cbfplot_wf(
             fields=[
                 "aslref",
                 "asl_mask",
+                "t1w_dseg",
                 "anat_to_aslref_xfm",
                 "template_to_anat_xfm",
-                "confounds_file",
+                "confounds_file",  # only for non-GE
                 # CBF outputs
-                "cbf_ts",
+                "cbf_ts",  # only for non-GE
                 "mean_cbf",
                 # SCORE/SCRUB outputs
-                "cbf_ts_score",
+                "cbf_ts_score",  # unused
                 "mean_cbf_score",
                 "mean_cbf_scrub",
                 "score_outlier_index",
@@ -58,188 +60,246 @@ def init_cbfplot_wf(
         ),
         name="inputnode",
     )
+
+    # String together transforms from MNI152NLin2009cAsym to ASL reference
     mrg_xfms = pe.Node(niu.Merge(2), name="mrg_xfms")
 
-    seg = get_template("MNI152NLin2009cAsym", resolution=1, desc="carpet", suffix="dseg")
-
-    resample_parc = pe.Node(
-        ApplyTransforms(
-            float=True,
-            input_image=str(seg),
-            dimension=3,
-            default_value=0,
-            interpolation="MultiLabel",
-        ),
-        name="resample_parc",
-    )
-
-    cbf_ts_summary = pe.Node(
-        CBFtsSummary(tr=metadata.get("RepetitionTime", metadata["RepetitionTimePreparation"])),
-        name="cbf_ts_summary",
-        mem_gb=2,
-    )
-    cbf_summary = pe.Node(CBFSummary(label="cbf", vmax=90), name="cbf_summary", mem_gb=1)
-    ds_report_cbftsplot = pe.Node(
-        DerivativesDataSink(desc="cbftsplot", datatype="figures", keep_dtype=True),
-        name="ds_report_cbftsplot",
-        run_without_submitting=True,
-        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-    )
-    ds_report_cbfplot = pe.Node(
-        DerivativesDataSink(desc="cbfplot", datatype="figures", keep_dtype=True),
-        name="ds_report_cbfplot",
-        run_without_submitting=True,
-        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-    )
     # fmt:off
     workflow.connect([
         (inputnode, mrg_xfms, [
             ("template_to_anat_xfm", "in1"),
             ("anat_to_aslref_xfm", "in2"),
         ]),
-        (inputnode, resample_parc, [("asl_mask", "reference_image")]),
-        (mrg_xfms, resample_parc, [("out", "transforms")]),
-        (resample_parc, cbf_ts_summary, [("output_image", "seg_file")]),
-        (inputnode, cbf_ts_summary, [
-            ("cbf_ts", "cbf_ts"),
-            ("confounds_file", "confounds_file"),
-            ("score_outlier_index", "score_outlier_index"),
-        ]),
-        (cbf_ts_summary, ds_report_cbftsplot, [("out_file", "in_file")]),
-        (inputnode, cbf_summary, [
-            ("mean_cbf", "cbf"),
-            ("aslref", "ref_vol"),
-        ]),
-        (cbf_summary, ds_report_cbfplot, [("out_file", "in_file")]),
     ])
     # fmt:on
 
-    if scorescrub:
-        score_summary = pe.Node(CBFSummary(label="score", vmax=90), name="score_summary", mem_gb=1)
-        scrub_summary = pe.Node(CBFSummary(label="scrub", vmax=90), name="scrub_summary", mem_gb=1)
-        ds_report_scoreplot = pe.Node(
-            DerivativesDataSink(desc="scoreplot", datatype="figures", keep_dtype=True),
-            name="ds_report_scoreplot",
-            run_without_submitting=True,
-            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-        )
-        ds_report_scrubplot = pe.Node(
-            DerivativesDataSink(desc="scrubplot", datatype="figures", keep_dtype=True),
-            name="ds_report_scrubplot",
-            run_without_submitting=True,
-            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-        )
-        # fmt:off
-        workflow.connect([
-            (inputnode, score_summary, [
-                ("mean_cbf_score", "cbf"),
-                ("aslref", "ref_vol"),
-            ]),
-            (score_summary, ds_report_scoreplot, [("out_file", "in_file")]),
-            (inputnode, scrub_summary, [
-                ("mean_cbf_scrub", "cbf"),
-                ("aslref", "ref_vol"),
-            ]),
-            (scrub_summary, ds_report_scrubplot, [("out_file", "in_file")]),
-        ])
-        # fmt:on
-
-    if basil:
-        basil_summary = pe.Node(
-            CBFSummary(label="basil", vmax=100), name="basil_summary", mem_gb=1
-        )
-        pvc_summary = pe.Node(CBFSummary(label="pvc", vmax=120), name="pvc_summary", mem_gb=1)
-        ds_report_basilplot = pe.Node(
-            DerivativesDataSink(desc="basilplot", datatype="figures", keep_dtype=True),
-            name="ds_report_basilplot",
-            run_without_submitting=True,
-            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-        )
-        ds_report_pvcplot = pe.Node(
-            DerivativesDataSink(desc="pvcplot", datatype="figures", keep_dtype=True),
-            name="ds_report_pvcplot",
-            run_without_submitting=True,
-            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-        )
-
-        # fmt:off
-        workflow.connect([
-            (inputnode, basil_summary, [
-                ("mean_cbf_basil", "cbf"),
-                ("aslref", "ref_vol"),
-            ]),
-            (basil_summary, ds_report_basilplot, [("out_file", "in_file")]),
-            (inputnode, pvc_summary, [
-                ("mean_cbf_gm_basil", "cbf"),
-                ("aslref", "ref_vol"),
-            ]),
-            (pvc_summary, ds_report_pvcplot, [("out_file", "in_file")]),
-        ])
-        # fmt:on
-
-    return workflow
-
-
-def init_gecbfplot_wf(basil=False, name="cbf_plot"):
-    """Plot CBF results for GE data.
-
-    Workflow Graph
-        .. workflow::
-            :graph2use: orig
-            :simple_form: yes
-
-            from aslprep.workflows.asl.plotting import init_gecbfplot_wf
-
-            wf = init_gecbfplot_wf(basil=True)
-    """
-    workflow = Workflow(name=name)
-
-    inputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=[
-                "mean_cbf",
-                "aslref",
-                "mean_cbf_basil",
-                "mean_cbf_gm_basil",
-                "mean_cbf_wm_basil",  # unused
-            ],
+    # Warp dseg file from T1w space to ASL reference space
+    warp_t1w_dseg_to_aslref = pe.Node(
+        ApplyTransforms(
+            float=True,
+            dimension=3,
+            default_value=0,
+            interpolation="MultiLabel",
         ),
-        name="inputnode",
+        name="warp_t1w_dseg_to_aslref",
     )
 
-    cbf_summary = pe.Node(CBFSummary(label="cbf", vmax=90), name="cbf_summary", mem_gb=1)
-    ds_report_cbfplot = pe.Node(
-        DerivativesDataSink(desc="cbfplot", datatype="figures", keep_dtype=True),
-        name="ds_report_cbfplot",
-        run_without_submitting=True,
-        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+    # fmt:off
+    workflow.connect([
+        (inputnode, warp_t1w_dseg_to_aslref, [
+            ("asl_mask", "reference_image"),
+            ("t1w_dseg", "input_image"),
+            ("anat_to_aslref_xfm", "transforms"),
+        ]),
+    ])
+    # fmt:on
+
+    grab_carpet_dseg = pe.Node(
+        niu.Function(
+            input_names=["template", "kwargs"],
+            output_names=["carpet_dseg"],
+            function=get_template_str,
+        ),
+        name="grab_carpet_dseg",
     )
+    grab_carpet_dseg.inputs.template = "MNI152NLin2009cAsym"
+    grab_carpet_dseg.inputs.kwargs = {
+        "resolution": 1,
+        "desc": "carpet",
+        "suffix": "dseg",
+    }
+
+    warp_carpet_dseg_to_aslref = pe.Node(
+        ApplyTransforms(
+            float=True,
+            dimension=3,
+            default_value=0,
+            interpolation="MultiLabel",
+        ),
+        name="warp_carpet_dseg_to_aslref",
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, warp_carpet_dseg_to_aslref, [("asl_mask", "reference_image")]),
+        (mrg_xfms, warp_carpet_dseg_to_aslref, [("out", "transforms")]),
+        (grab_carpet_dseg, warp_carpet_dseg_to_aslref, [("carpet_dseg", "input_image")]),
+    ])
+    # fmt:on
+
+    if plot_timeseries:
+        # Time series are only available for non-GE data.
+        cbf_ts_summary = pe.Node(
+            CBFtsSummary(tr=metadata.get("RepetitionTime", metadata["RepetitionTimePreparation"])),
+            name="cbf_ts_summary",
+            mem_gb=2,
+        )
+
+        # fmt:off
+        workflow.connect([
+            (inputnode, cbf_ts_summary, [
+                ("cbf_ts", "cbf_ts"),
+                ("confounds_file", "confounds_file"),
+                ("score_outlier_index", "score_outlier_index"),
+            ]),
+            (warp_carpet_dseg_to_aslref, cbf_ts_summary, [("output_image", "seg_file")]),
+        ])
+        # fmt:on
+
+        ds_report_cbf_ts_summary = pe.Node(
+            DerivativesDataSink(desc="cbftsplot", datatype="figures", keep_dtype=True),
+            name="ds_report_cbf_ts_summary",
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
+        workflow.connect([(cbf_ts_summary, ds_report_cbf_ts_summary, [("out_file", "in_file")])])
+
+    cbf_summary = pe.Node(CBFSummary(label="cbf", vmax=100), name="cbf_summary", mem_gb=1)
+
     # fmt:off
     workflow.connect([
         (inputnode, cbf_summary, [
             ("mean_cbf", "cbf"),
             ("aslref", "ref_vol"),
         ]),
-        (cbf_summary, ds_report_cbfplot, [("out_file", "in_file")]),
     ])
     # fmt:on
 
+    ds_report_cbf_summary = pe.Node(
+        DerivativesDataSink(desc="cbfplot", datatype="figures", keep_dtype=True),
+        name="ds_report_cbf_summary",
+        run_without_submitting=True,
+        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+    )
+
+    workflow.connect([(cbf_summary, ds_report_cbf_summary, [("out_file", "in_file")])])
+
+    cbf_by_tt_plot = pe.Node(
+        CBFByTissueTypePlot(),
+        name="cbf_by_tt_plot",
+    )
+
+    # fmt:off
+    workflow.connect([
+        (inputnode, cbf_by_tt_plot, [("mean_cbf", "cbf")]),
+        (warp_t1w_dseg_to_aslref, cbf_by_tt_plot, [("output_image", "seg_file")]),
+    ])
+    # fmt:on
+
+    ds_report_cbf_to_tt_plot = pe.Node(
+        DerivativesDataSink(desc="cbfByTissueType", datatype="figures", keep_dtype=True),
+        name="ds_report_cbf_to_tt_plot",
+        run_without_submitting=True,
+        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+    )
+
+    workflow.connect([(cbf_by_tt_plot, ds_report_cbf_to_tt_plot, [("out_file", "in_file")])])
+
+    if scorescrub:
+        score_summary = pe.Node(
+            CBFSummary(label="score", vmax=100),
+            name="score_summary",
+            mem_gb=1,
+        )
+
+        # fmt:off
+        workflow.connect([
+            (inputnode, score_summary, [
+                ("mean_cbf_score", "cbf"),
+                ("aslref", "ref_vol"),
+            ]),
+        ])
+        # fmt:on
+
+        ds_report_score_summary = pe.Node(
+            DerivativesDataSink(desc="scoreplot", datatype="figures", keep_dtype=True),
+            name="ds_report_score_summary",
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
+        workflow.connect([(score_summary, ds_report_score_summary, [("out_file", "in_file")])])
+
+        score_by_tt_plot = pe.Node(
+            CBFByTissueTypePlot(),
+            name="score_by_tt_plot",
+        )
+
+        # fmt:off
+        workflow.connect([
+            (inputnode, score_by_tt_plot, [("mean_cbf_score", "cbf")]),
+            (warp_t1w_dseg_to_aslref, score_by_tt_plot, [("output_image", "seg_file")]),
+        ])
+        # fmt:on
+
+        ds_report_score_by_tt_plot = pe.Node(
+            DerivativesDataSink(desc="scoreByTissueType", datatype="figures", keep_dtype=True),
+            name="ds_report_score_by_tt_plot",
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
+        # fmt:off
+        workflow.connect([
+            (score_by_tt_plot, ds_report_score_by_tt_plot, [("out_file", "in_file")]),
+        ])
+        # fmt:on
+
+        scrub_summary = pe.Node(
+            CBFSummary(label="scrub", vmax=100),
+            name="scrub_summary",
+            mem_gb=1,
+        )
+
+        # fmt:off
+        workflow.connect([
+            (inputnode, scrub_summary, [
+                ("mean_cbf_scrub", "cbf"),
+                ("aslref", "ref_vol"),
+            ]),
+        ])
+        # fmt:on
+
+        ds_report_scrub_summary = pe.Node(
+            DerivativesDataSink(desc="scrubplot", datatype="figures", keep_dtype=True),
+            name="ds_report_scrub_summary",
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
+        workflow.connect([(scrub_summary, ds_report_scrub_summary, [("out_file", "in_file")])])
+
+        scrub_by_tt_plot = pe.Node(
+            CBFByTissueTypePlot(),
+            name="scrub_by_tt_plot",
+        )
+
+        # fmt:off
+        workflow.connect([
+            (inputnode, scrub_by_tt_plot, [("mean_cbf_scrub", "cbf")]),
+            (warp_t1w_dseg_to_aslref, scrub_by_tt_plot, [("output_image", "seg_file")]),
+        ])
+        # fmt:on
+
+        ds_report_scrub_by_tt_plot = pe.Node(
+            DerivativesDataSink(desc="scrubByTissueType", datatype="figures", keep_dtype=True),
+            name="ds_report_scrub_by_tt_plot",
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
+        # fmt:off
+        workflow.connect([
+            (scrub_by_tt_plot, ds_report_scrub_by_tt_plot, [("out_file", "in_file")]),
+        ])
+        # fmt:on
+
     if basil:
         basil_summary = pe.Node(
-            CBFSummary(label="basil", vmax=100), name="basil_summary", mem_gb=1
-        )
-        pvc_summary = pe.Node(CBFSummary(label="pvc", vmax=120), name="pvc_summary", mem_gb=1)
-        ds_report_basilplot = pe.Node(
-            DerivativesDataSink(desc="basilplot", datatype="figures", keep_dtype=True),
-            name="ds_report_basilplot",
-            run_without_submitting=True,
-            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-        )
-        ds_report_pvcplot = pe.Node(
-            DerivativesDataSink(desc="pvcplot", datatype="figures", keep_dtype=True),
-            name="ds_report_pvcplot",
-            run_without_submitting=True,
-            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+            CBFSummary(label="basil", vmax=100),
+            name="basil_summary",
+            mem_gb=1,
         )
 
         # fmt:off
@@ -248,13 +308,86 @@ def init_gecbfplot_wf(basil=False, name="cbf_plot"):
                 ("mean_cbf_basil", "cbf"),
                 ("aslref", "ref_vol"),
             ]),
-            (basil_summary, ds_report_basilplot, [("out_file", "in_file")]),
+        ])
+        # fmt:on
+
+        ds_report_basil_summary = pe.Node(
+            DerivativesDataSink(desc="basilplot", datatype="figures", keep_dtype=True),
+            name="ds_report_basil_summary",
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
+        workflow.connect([(basil_summary, ds_report_basil_summary, [("out_file", "in_file")])])
+
+        basil_by_tt_plot = pe.Node(
+            CBFByTissueTypePlot(),
+            name="basil_by_tt_plot",
+        )
+
+        # fmt:off
+        workflow.connect([
+            (inputnode, basil_by_tt_plot, [("mean_cbf_basil", "cbf")]),
+            (warp_t1w_dseg_to_aslref, basil_by_tt_plot, [("output_image", "seg_file")]),
+        ])
+        # fmt:on
+
+        ds_report_basil_by_tt_plot = pe.Node(
+            DerivativesDataSink(desc="basilByTissueType", datatype="figures", keep_dtype=True),
+            name="ds_report_basil_by_tt_plot",
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
+        # fmt:off
+        workflow.connect([
+            (basil_by_tt_plot, ds_report_basil_by_tt_plot, [("out_file", "in_file")]),
+        ])
+        # fmt:on
+
+        pvc_summary = pe.Node(
+            CBFSummary(label="pvc", vmax=120),
+            name="pvc_summary",
+            mem_gb=1,
+        )
+
+        # fmt:off
+        workflow.connect([
             (inputnode, pvc_summary, [
                 ("mean_cbf_gm_basil", "cbf"),
                 ("aslref", "ref_vol"),
             ]),
-            (pvc_summary, ds_report_pvcplot, [("out_file", "in_file")]),
         ])
         # fmt:on
+
+        ds_report_pvc_summary = pe.Node(
+            DerivativesDataSink(desc="pvcplot", datatype="figures", keep_dtype=True),
+            name="ds_report_pvc_summary",
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
+        workflow.connect([(pvc_summary, ds_report_pvc_summary, [("out_file", "in_file")])])
+
+        pvc_by_tt_plot = pe.Node(
+            CBFByTissueTypePlot(),
+            name="pvc_by_tt_plot",
+        )
+
+        # fmt:off
+        workflow.connect([
+            (inputnode, pvc_by_tt_plot, [("mean_cbf_gm_basil", "cbf")]),
+            (warp_t1w_dseg_to_aslref, pvc_by_tt_plot, [("output_image", "seg_file")]),
+        ])
+        # fmt:on
+
+        ds_report_pvc_by_tt_plot = pe.Node(
+            DerivativesDataSink(desc="pvcByTissueType", datatype="figures", keep_dtype=True),
+            name="ds_report_pvc_by_tt_plot",
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
+        workflow.connect([(pvc_by_tt_plot, ds_report_pvc_by_tt_plot, [("out_file", "in_file")])])
 
     return workflow

--- a/aslprep/workflows/asl/plotting.py
+++ b/aslprep/workflows/asl/plotting.py
@@ -145,7 +145,9 @@ def init_cbfplot_wf(
         # fmt:on
 
     if basil:
-        basil_summary = pe.Node(CBFSummary(label="basil", vmax=100), name="basil_summary", mem_gb=1)
+        basil_summary = pe.Node(
+            CBFSummary(label="basil", vmax=100), name="basil_summary", mem_gb=1
+        )
         pvc_summary = pe.Node(CBFSummary(label="pvc", vmax=120), name="pvc_summary", mem_gb=1)
         ds_report_basilplot = pe.Node(
             DerivativesDataSink(desc="basilplot", datatype="figures", keep_dtype=True),
@@ -223,7 +225,9 @@ def init_gecbfplot_wf(basil=False, name="cbf_plot"):
     # fmt:on
 
     if basil:
-        basil_summary = pe.Node(CBFSummary(label="basil", vmax=100), name="basil_summary", mem_gb=1)
+        basil_summary = pe.Node(
+            CBFSummary(label="basil", vmax=100), name="basil_summary", mem_gb=1
+        )
         pvc_summary = pe.Node(CBFSummary(label="pvc", vmax=120), name="pvc_summary", mem_gb=1)
         ds_report_basilplot = pe.Node(
             DerivativesDataSink(desc="basilplot", datatype="figures", keep_dtype=True),

--- a/aslprep/workflows/asl/plotting.py
+++ b/aslprep/workflows/asl/plotting.py
@@ -73,12 +73,12 @@ def init_cbfplot_wf(
         name="resample_parc",
     )
 
-    cbftssummary = pe.Node(
+    cbf_ts_summary = pe.Node(
         CBFtsSummary(tr=metadata.get("RepetitionTime", metadata["RepetitionTimePreparation"])),
         name="cbf_ts_summary",
         mem_gb=2,
     )
-    cbfsummary = pe.Node(CBFSummary(label="cbf", vmax=90), name="cbf_summary", mem_gb=1)
+    cbf_summary = pe.Node(CBFSummary(label="cbf", vmax=90), name="cbf_summary", mem_gb=1)
     ds_report_cbftsplot = pe.Node(
         DerivativesDataSink(desc="cbftsplot", datatype="figures", keep_dtype=True),
         name="ds_report_cbftsplot",
@@ -99,24 +99,24 @@ def init_cbfplot_wf(
         ]),
         (inputnode, resample_parc, [("asl_mask", "reference_image")]),
         (mrg_xfms, resample_parc, [("out", "transforms")]),
-        (resample_parc, cbftssummary, [("output_image", "seg_file")]),
-        (inputnode, cbftssummary, [
+        (resample_parc, cbf_ts_summary, [("output_image", "seg_file")]),
+        (inputnode, cbf_ts_summary, [
             ("cbf_ts", "cbf_ts"),
             ("confounds_file", "confounds_file"),
             ("score_outlier_index", "score_outlier_index"),
         ]),
-        (cbftssummary, ds_report_cbftsplot, [("out_file", "in_file")]),
-        (inputnode, cbfsummary, [
+        (cbf_ts_summary, ds_report_cbftsplot, [("out_file", "in_file")]),
+        (inputnode, cbf_summary, [
             ("mean_cbf", "cbf"),
             ("aslref", "ref_vol"),
         ]),
-        (cbfsummary, ds_report_cbfplot, [("out_file", "in_file")]),
+        (cbf_summary, ds_report_cbfplot, [("out_file", "in_file")]),
     ])
     # fmt:on
 
     if scorescrub:
-        scoresummary = pe.Node(CBFSummary(label="score", vmax=90), name="score_summary", mem_gb=1)
-        scrubsummary = pe.Node(CBFSummary(label="scrub", vmax=90), name="scrub_summary", mem_gb=1)
+        score_summary = pe.Node(CBFSummary(label="score", vmax=90), name="score_summary", mem_gb=1)
+        scrub_summary = pe.Node(CBFSummary(label="scrub", vmax=90), name="scrub_summary", mem_gb=1)
         ds_report_scoreplot = pe.Node(
             DerivativesDataSink(desc="scoreplot", datatype="figures", keep_dtype=True),
             name="ds_report_scoreplot",
@@ -131,22 +131,22 @@ def init_cbfplot_wf(
         )
         # fmt:off
         workflow.connect([
-            (inputnode, scoresummary, [
+            (inputnode, score_summary, [
                 ("mean_cbf_score", "cbf"),
                 ("aslref", "ref_vol"),
             ]),
-            (scoresummary, ds_report_scoreplot, [("out_file", "in_file")]),
-            (inputnode, scrubsummary, [
+            (score_summary, ds_report_scoreplot, [("out_file", "in_file")]),
+            (inputnode, scrub_summary, [
                 ("mean_cbf_scrub", "cbf"),
                 ("aslref", "ref_vol"),
             ]),
-            (scrubsummary, ds_report_scrubplot, [("out_file", "in_file")]),
+            (scrub_summary, ds_report_scrubplot, [("out_file", "in_file")]),
         ])
         # fmt:on
 
     if basil:
-        basilsummary = pe.Node(CBFSummary(label="basil", vmax=100), name="basil_summary", mem_gb=1)
-        pvcsummary = pe.Node(CBFSummary(label="pvc", vmax=120), name="pvc_summary", mem_gb=1)
+        basil_summary = pe.Node(CBFSummary(label="basil", vmax=100), name="basil_summary", mem_gb=1)
+        pvc_summary = pe.Node(CBFSummary(label="pvc", vmax=120), name="pvc_summary", mem_gb=1)
         ds_report_basilplot = pe.Node(
             DerivativesDataSink(desc="basilplot", datatype="figures", keep_dtype=True),
             name="ds_report_basilplot",
@@ -162,16 +162,16 @@ def init_cbfplot_wf(
 
         # fmt:off
         workflow.connect([
-            (inputnode, basilsummary, [
+            (inputnode, basil_summary, [
                 ("mean_cbf_basil", "cbf"),
                 ("aslref", "ref_vol"),
             ]),
-            (basilsummary, ds_report_basilplot, [("out_file", "in_file")]),
-            (inputnode, pvcsummary, [
+            (basil_summary, ds_report_basilplot, [("out_file", "in_file")]),
+            (inputnode, pvc_summary, [
                 ("mean_cbf_gm_basil", "cbf"),
                 ("aslref", "ref_vol"),
             ]),
-            (pvcsummary, ds_report_pvcplot, [("out_file", "in_file")]),
+            (pvc_summary, ds_report_pvcplot, [("out_file", "in_file")]),
         ])
         # fmt:on
 
@@ -205,7 +205,7 @@ def init_gecbfplot_wf(basil=False, name="cbf_plot"):
         name="inputnode",
     )
 
-    cbfsummary = pe.Node(CBFSummary(label="cbf", vmax=90), name="cbf_summary", mem_gb=1)
+    cbf_summary = pe.Node(CBFSummary(label="cbf", vmax=90), name="cbf_summary", mem_gb=1)
     ds_report_cbfplot = pe.Node(
         DerivativesDataSink(desc="cbfplot", datatype="figures", keep_dtype=True),
         name="ds_report_cbfplot",
@@ -214,17 +214,17 @@ def init_gecbfplot_wf(basil=False, name="cbf_plot"):
     )
     # fmt:off
     workflow.connect([
-        (inputnode, cbfsummary, [
+        (inputnode, cbf_summary, [
             ("mean_cbf", "cbf"),
             ("aslref", "ref_vol"),
         ]),
-        (cbfsummary, ds_report_cbfplot, [("out_file", "in_file")]),
+        (cbf_summary, ds_report_cbfplot, [("out_file", "in_file")]),
     ])
     # fmt:on
 
     if basil:
-        basilsummary = pe.Node(CBFSummary(label="basil", vmax=100), name="basil_summary", mem_gb=1)
-        pvcsummary = pe.Node(CBFSummary(label="pvc", vmax=120), name="pvc_summary", mem_gb=1)
+        basil_summary = pe.Node(CBFSummary(label="basil", vmax=100), name="basil_summary", mem_gb=1)
+        pvc_summary = pe.Node(CBFSummary(label="pvc", vmax=120), name="pvc_summary", mem_gb=1)
         ds_report_basilplot = pe.Node(
             DerivativesDataSink(desc="basilplot", datatype="figures", keep_dtype=True),
             name="ds_report_basilplot",
@@ -240,16 +240,16 @@ def init_gecbfplot_wf(basil=False, name="cbf_plot"):
 
         # fmt:off
         workflow.connect([
-            (inputnode, basilsummary, [
+            (inputnode, basil_summary, [
                 ("mean_cbf_basil", "cbf"),
                 ("aslref", "ref_vol"),
             ]),
-            (basilsummary, ds_report_basilplot, [("out_file", "in_file")]),
-            (inputnode, pvcsummary, [
+            (basil_summary, ds_report_basilplot, [("out_file", "in_file")]),
+            (inputnode, pvc_summary, [
                 ("mean_cbf_gm_basil", "cbf"),
                 ("aslref", "ref_vol"),
             ]),
-            (pvcsummary, ds_report_pvcplot, [("out_file", "in_file")]),
+            (pvc_summary, ds_report_pvcplot, [("out_file", "in_file")]),
         ])
         # fmt:on
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -392,7 +392,7 @@ An example of CBF denoised by SCRUB is shown below.
    Computed CBF maps denoised by SCRUB
 
 *ASLPrep* also includes option of CBF computation by Bayesian Inference for Arterial Spin Labeling
-`(BASIL) <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BASIL>`_.
+(`BASIL <https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/BASIL>`_).
 BASIL also implements a simple kinetic model as described above,
 but using Bayesian Inference principles :footcite:p:`chappell2008variational`.
 BASIL is mostly suitable for multi-PLD.


### PR DESCRIPTION
Closes #284 and closes #277.

## Changes proposed in this pull request

- Improve settings for CBF stat-map plots.
- Add strip/box-plots that show the distribution of CBF values by tissue type, for each of the CBF outputs.
- Add `plot_timeseries` parameter to `init_cbfplot_wf`, so that it can be used for GE data.
- Remove `init_gecbfplot_wf`.
- Select the MNI152NLin2009cAsym-to-anat transform to warp the carpet plot's dseg file in the plotting workflow. Before, it was just using all of the template-to-anat transforms, AFAICT.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/pennlinc/aslprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (BSD 3-Clause) as the rest of ASLPrep.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
