### PR TITLE
Fix deployment configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,13 +454,7 @@ jobs:
           no_output_timeout: 3h
           command: |
             # Get version, update files.
-            THISVERSION=$( python3 get_version.py )
-            if [[ ${THISVERSION:0:1} == "0" ]] ; then
-              echo "WARNING: latest git tag could not be found"
-              echo "Please, make sure you fetch all tags from upstream with"
-              echo "the command ``git fetch --tags --verbose`` and push"
-              echo "them to your fork with ``git push origin --tags``"
-            fi
+            THISVERSION=$(python -c "from aslprep import __version__; print(__version__)")
             sed -i "s/title = {aslprep}/title = {aslprep ${CIRCLE_TAG:-$THISVERSION}}/" aslprep/data/boilerplate.bib
             # Build docker image
             e=1 && for i in {1..5}; do


### PR DESCRIPTION
Closes None. I just noticed that the deployment job wasn't working after I restructured ASLPrep's packaging.

## Changes proposed in this pull request

- Replace `get_version.py` call (file was removed) with `python -c` command.