### PR TITLE
Fix Docker build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ FROM pennlinc/aslprep_build:main
 # Install aslprep
 COPY . /src/aslprep
 
-ARG VERSION=0.0.1
+ARG VERSION=0.4.1
 
 # Force static versioning within container
 RUN echo "${VERSION}" > /src/aslprep/aslprep/VERSION && \
-    echo "include aslprep/VERSION" >> /src/aslprep/MANIFEST.in && \
-    pip install --no-cache-dir "/src/aslprep[all]"
+    echo "include aslprep/VERSION" >> /src/aslprep/MANIFEST.in \
+    pip install --no-cache-dir "/src/aslprep[doc,maint,test]"
 
 RUN find $HOME -type d -exec chmod go=u {} + && \
     find $HOME -type f -exec chmod go=u {} + && \


### PR DESCRIPTION
Closes #308.

## Changes proposed in this pull request

- For some reason, the `all` dependency group alias is causing problems within the Docker build. It's fine when I install ASLPrep locally. Swapping out `aslprep[all]` with `aslprep[doc,maint,test]` seems to have fixed the issue.