### PR TITLE
Patch regmotoasl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,36 @@
+## 0.4.0
+
+This release re-implements multi-delay PCASL and single-delay Q2TIPS PASL support.
+
+Additionally, we have replaced certain BOLD-specific steps with ASL-compatible alternatives. One such case is slice timing correction. Rather than interpolate the ASL time series to perform slice timing correction (as in BOLD preprocessing), ASLPrep now shifts PLDs according to the slice timing. The other major change is to motion correction, which is now performed separately for each image type in the ASL time series (e.g., control, label, and M0 volumes).
+
+Thanks to Sudipto Dolui, Jian Hu, Jan Petr, Manuel Taso, and Kay Jann for their help and feedback.
+
+<!-- Release notes generated using configuration in .github/release.yml at main -->
+
+## What's Changed
+### 🛠 Breaking Changes
+* Use same TPM threshold for GE and non-GE data by @tsalo in https://github.com/PennLINC/aslprep/pull/263
+* Remove slice-timing correction by @tsalo in https://github.com/PennLINC/aslprep/pull/269
+### 🎉 Exciting New Features
+* Shift PostLabelingDelay(s) by slice times by @tsalo in https://github.com/PennLINC/aslprep/pull/280
+* Perform motion correction separately for each image type by @tsalo in https://github.com/PennLINC/aslprep/pull/275
+* Support single-PLD Q2TIPS PASL and multi-PLD PCASL by @tsalo in https://github.com/PennLINC/aslprep/pull/268
+### 🐛 Bug Fixes
+* Support runs with SCORE/SCRUB disabled by @tsalo in https://github.com/PennLINC/aslprep/pull/279
+* Reorganize atlases and add them to the package data by @tsalo in https://github.com/PennLINC/aslprep/pull/282
+### Other Changes
+* Refactor workflow connections by @tsalo in https://github.com/PennLINC/aslprep/pull/261
+* Refactor more by @tsalo in https://github.com/PennLINC/aslprep/pull/264
+* Remove unused workflows by @tsalo in https://github.com/PennLINC/aslprep/pull/271
+* Remove test-made nifti files before storing artifacts by @tsalo in https://github.com/PennLINC/aslprep/pull/274
+* Improve plots by @tsalo in https://github.com/PennLINC/aslprep/pull/286
+* Remove multi-echo elements by @tsalo in https://github.com/PennLINC/aslprep/pull/294
+* Document M0 scaling by @tsalo in https://github.com/PennLINC/aslprep/pull/292
+
+
+**Full Changelog**: https://github.com/PennLINC/aslprep/compare/0.3.0...0.4.0
+
 ## 0.3.0
 
 0.3.0 reflects renewed maintenance for ASLPrep.

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@
    :target: https://zenodo.org/badge/latestdoi/256420694
    :alt: Zenodo DOI
 
-.. image:: https://img.shields.io/github/license/pennlinc/aslprep
+.. image:: https://img.shields.io/badge/License-BSD--3--Clause-green
    :target: https://opensource.org/licenses/BSD-3-Clause
    :alt: License
 

--- a/aslprep/interfaces/cbf.py
+++ b/aslprep/interfaces/cbf.py
@@ -963,17 +963,17 @@ def regmotoasl(asl, m0file, m02asl):
     meanasl = fsl.MeanImage()
     meanasl.inputs.in_file = asl
     meanasl.inputs.out_file = fname_presuffix(asl, suffix="_meanasl")
-    meanasl.run()
+    meanasl_results = meanasl.run()
     meanm0 = fsl.MeanImage()
     meanm0.inputs.in_file = m0file
     meanm0.inputs.out_file = fname_presuffix(asl, suffix="_meanm0")
-    meanm0.run()
+    meanm0_results = meanm0.run()
     flt = fsl.FLIRT(bins=640, cost_func="mutualinfo")
-    flt.inputs.in_file = meanm0.inputs.out_file
-    flt.inputs.reference = meanasl.inputs.out_file
+    flt.inputs.in_file = meanm0_results.outputs.out_file
+    flt.inputs.reference = meanasl_results.outputs.out_file
     flt.inputs.out_file = m02asl
-    flt.run()
-    return m02asl
+    flt_results = flt.run()
+    return flt_results.outputs.out_file
 
 
 def refine_ref_mask(t1w_mask, ref_asl_mask, t12ref_transform, tmp_mask, refined_mask):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,10 @@ doc = [
     "pydot >= 1.2.3",
     "pydotplus",
     "recommonmark",
-    "sphinx >= 4.2.0",
+    "sphinx >= 6.2.1",
     "sphinx-argparse",
     "sphinx-markdown-tables",
-    "sphinx_rtd_theme",
+    "sphinx_rtd_theme >= 1.2.2",
     "sphinxcontrib-apidoc",
     "sphinxcontrib-bibtex",
 ]


### PR DESCRIPTION
Closes #319.

## Changes proposed in this pull request

- Instead of relying on the input `out_file`, pass the output `out_file` from the interface's results object.
- Fix the README's license badge.
- Add 0.4.0 release notes to the CHANGES file.