### PR TITLE
Make M0 TR optional for BASIL

### DIFF
--- a/aslprep/interfaces/cbf.py
+++ b/aslprep/interfaces/cbf.py
@@ -192,17 +192,23 @@ class ExtractCBF(SimpleInterface):
                 control_img = smooth_image(control_img, fwhm=self.inputs.fwhm).get_fdata()
                 m0data = mask_data * np.mean(control_img, axis=3)
 
+                # Use the control volumes' TR as the M0 TR.
+                if np.array(metadata["RepetitionTimePreparation"]).size > 1:
+                    m0tr = np.array(metadata["RepetitionTimePreparation"])[control_volume_idx[0]]
+                else:
+                    m0tr = metadata["RepetitionTimePreparation"]
+
             elif cbf_volume_idx:
                 # If we have precalculated CBF data, we don't need M0, so we'll just use the mask.
                 m0data = mask_data
+
+                m0tr = None
 
             else:
                 raise RuntimeError(
                     "m0scan is absent, "
                     "and there are no control volumes that can be used as a substitute"
                 )
-
-            m0tr = None
 
         else:
             raise RuntimeError("no pathway to m0scan")
@@ -823,7 +829,7 @@ class _BASILCBFInputSpec(FSLCommandInputSpec):
     m0tr = traits.Float(
         desc="The repetition time for the calibration image (the M0 scan).",
         argstr="--tr %.2f",
-        mandatory=True,
+        mandatory=False,
     )
     tis = traits.Either(
         traits.Float(),

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -851,7 +851,7 @@ perfusion image, including correction of partial volume effects [@chappell_pvc].
         # fmt:on
 
         if metadata["M0Type"] != "Estimate":
-            workflow.connect([(extract_deltam, basilcbf, [("m0tr", "m0tr")])])
+            workflow.connect([(inputnode, basilcbf, [("m0tr", "m0tr")])])
 
     return workflow
 

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -466,7 +466,6 @@ additionally calculates a partial-volume corrected CBF image [@chappell_pvc].
                 (("m0_file", _getfiledir), "out_basename"),
                 ("out_file", "deltam"),
                 ("m0_file", "mzero"),
-                ("m0tr", "m0tr"),
             ]),
             (determine_bolus_duration, basilcbf, [("bolus", "bolus")]),
             (determine_inflow_times, basilcbf, [("tis", "tis")]),
@@ -481,6 +480,9 @@ additionally calculates a partial-volume corrected CBF image [@chappell_pvc].
             ]),
         ])
         # fmt:on
+
+        if metadata["M0Type"] != "Estimate":
+            workflow.connect([(extract_deltam, basilcbf, [("m0tr", "m0tr")])])
 
     return workflow
 
@@ -834,7 +836,6 @@ perfusion image, including correction of partial volume effects [@chappell_pvc].
             (inputnode, basilcbf, [
                 (("asl_mask", _getfiledir), "out_basename"),
                 ("m0_file", "mzero"),
-                ("m0tr", "m0tr"),
             ]),
             (collect_cbf, basilcbf, [("deltam", "deltam")]),
             (gm_tfm, basilcbf, [("output_image", "gm_tpm")]),
@@ -848,6 +849,9 @@ perfusion image, including correction of partial volume effects [@chappell_pvc].
             ]),
         ])
         # fmt:on
+
+        if metadata["M0Type"] != "Estimate":
+            workflow.connect([(extract_deltam, basilcbf, [("m0tr", "m0tr")])])
 
     return workflow
 


### PR DESCRIPTION
Closes #322.

## Changes proposed in this pull request

- Use the control volumes' TR for BASIL's M0 TR if M0Type is "absent".
- Do not set an M0 TR for BASIL if M0Type is "estimate".