### PR TITLE
Fix `BolusCutOffTechnique` typo

### DIFF
--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -154,7 +154,7 @@ PLD + labeling duration > ATT.
 """
 
     else:
-        bcut = metadata.get("BolusCutOffDelayTechnique")
+        bcut = metadata.get("BolusCutOffTechnique")
 
         if is_multi_pld:
             raise ValueError(


### PR DESCRIPTION
Closes #327. Unfortunately, tests only cover the `ComputeCBF` interface, not the `init_compute_cbf_wf` workflow, where the typo was.

## Changes proposed in this pull request

- Fix typo where `BolusCutOffTechnique` was misspelled as `BolusCutOffDelayTechnique`.