### PR TITLE
Pin scipy version to 1.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "psutil >= 5.4",
     "pybids >= 0.13.2",
     "pyyaml",
+    "scipy == 1.10.1",  # 1.11 introduces backwards incompatible change to scipy.stats.mode that doesn't work with bundled SDCFlows
     "sdcflows",
     "sentry-sdk >= 0.6.9",
     "smriprep == 0.10",


### PR DESCRIPTION
Closes None, but patches a problem with the bundled version of SDCFlows.

## Changes proposed in this pull request
- Pin Scipy version to 1.10.1 (working version from ASLPrep 0.5.1rc1).
    - I should be able to drop this version restriction when I finally get around to excising the interal copy of SDCFlows in favor of an installed version.

## Origins of the problem

I noticed the following error with 0.5.1:

```
231019-14:51:59,708 nipype.workflow ERROR:
         could not run node: aslprep_wf.single_subject_xxxx_wf.asl_preproc_ses_xxxx_acq_se_wf.sdc_estimate_wf.phdiff_wf.fmap_postproc_wf.demean
231019-14:51:59,878 nipype.workflow CRITICAL:
         ASLPrep failed: Traceback (most recent call last):
  File "/usr/local/miniconda/lib/python3.9/site-packages/nipype/pipeline/plugins/multiproc.py", line 67, in run_node
    result["result"] = node.run(updatehash=updatehash)
  File "/usr/local/miniconda/lib/python3.9/site-packages/nipype/pipeline/engine/nodes.py", line 527, in run
    result = self._run_interface(execute=True)
  File "/usr/local/miniconda/lib/python3.9/site-packages/nipype/pipeline/engine/nodes.py", line 645, in _run_interface
    return self._run_command(execute)
  File "/usr/local/miniconda/lib/python3.9/site-packages/nipype/pipeline/engine/nodes.py", line 771, in _run_command
    raise NodeExecutionError(msg)
nipype.pipeline.engine.nodes.NodeExecutionError: Exception raised while executing Node demean.

Traceback:
	Traceback (most recent call last):
          File "/usr/local/miniconda/lib/python3.9/site-packages/nipype/interfaces/base/core.py", line 397, in run
            runtime = self._run_interface(runtime)
          File "/usr/local/miniconda/lib/python3.9/site-packages/nipype/interfaces/utility/wrappers.py", line 142, in _run_interface
            out = function_handle(**args)
          File "<string>", line 26, in _demean
        IndexError: invalid index to scalar variable.
```

After some digging, it became clear that the problem was due to `data[msk] -= mode(data[msk], axis=None)[0][0]`. Scipy version 1.11 introduced backwards-incompatible changes to `scipy.stats.mode` that are breaking this step. I'm sure that more current versions of SDCFlows don't have this problem, but the bundled (quite old) version in ASLPrep does.