### PR TITLE
Raise error if no M0 volume(s)/estimate available and background suppression is enabled

### DIFF
--- a/aslprep/interfaces/cbf.py
+++ b/aslprep/interfaces/cbf.py
@@ -185,6 +185,13 @@ class ExtractCBF(SimpleInterface):
             m0tr = None
 
         elif metadata["M0Type"] == "Absent":
+            if control_volume_idx and not cbf_volume_idx:
+                # BackgroundSuppression is required, so no need to use get().
+                if metadata["BackgroundSuppression"]:
+                    raise ValueError(
+                        "Background-suppressed control volumes cannot be used for calibration."
+                    )
+
             if control_volume_idx:
                 # Estimate M0 using the smoothed mean control volumes.
                 control_data = asl_data[:, :, :, control_volume_idx]

--- a/aslprep/interfaces/ge.py
+++ b/aslprep/interfaces/ge.py
@@ -139,6 +139,11 @@ class GeReferenceFile(SimpleInterface):
             if not control_volume_idx:
                 raise RuntimeError("M0 could not be estimated from control volumes.")
 
+            if metadata["BackgroundSuppression"]:
+                raise ValueError(
+                    "Background-suppressed control volumes cannot be used for calibration."
+                )
+
             control_data = asl_data[:, :, :, control_volume_idx]
             m0_data = np.mean(control_data, axis=3)
 

--- a/aslprep/utils/asl.py
+++ b/aslprep/utils/asl.py
@@ -47,7 +47,7 @@ def select_processing_target(aslcontext):
     try:
         aslcontext_df = pd.read_table(aslcontext)
     except:
-        raise ValueError(aslcontext)
+        raise FileNotFoundError(aslcontext)
 
     voltypes = aslcontext_df["volume_type"].tolist()
 


### PR DESCRIPTION
Closes #335.

## Changes proposed in this pull request

- When `M0Type` is "Absent" and CBF volumes are not already available, check if background suppression is enabled. If it _is_, then raise a `ValueError`, as the control volumes cannot be used for calibration when background suppression is enabled.