### PR TITLE
Limit BASIL `--slicedt` argument to ascending slice orders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,7 @@ jobs:
             mkdir /src/coverage
             mv /src/aslprep/.coverage /src/coverage/.coverage.test_002
             # remove nifti files before uploading artifacts
-            # find /src/aslprep/.circleci/out/ -name "*.nii.gz" -type f -delete
+            find /src/aslprep/.circleci/out/ -name "*.nii.gz" -type f -delete
       - store_artifacts:
           path: /src/aslprep/.circleci/out
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,7 @@ jobs:
             mkdir /src/coverage
             mv /src/aslprep/.coverage /src/coverage/.coverage.test_002
             # remove nifti files before uploading artifacts
-            find /src/aslprep/.circleci/out/ -name "*.nii.gz" -type f -delete
+            # find /src/aslprep/.circleci/out/ -name "*.nii.gz" -type f -delete
       - store_artifacts:
           path: /src/aslprep/.circleci/out
       - persist_to_workspace:

--- a/aslprep/interfaces/cbf.py
+++ b/aslprep/interfaces/cbf.py
@@ -426,6 +426,11 @@ class _ComputeCBFOutputSpec(TraitedSpec):
         None,
         desc="Arterial transit time map, in seconds. Only generated for multi-delay data.",
     )
+    plds = traits.Either(
+        File(exists=True),
+        None,
+        desc="Post-labeling delays. Only defined if slice-timing correction is applied.",
+    )
 
 
 class ComputeCBF(SimpleInterface):
@@ -520,6 +525,7 @@ class ComputeCBF(SimpleInterface):
         m0data = np.mean(m0data, axis=0)
         scaled_m0data = m0_scale * m0data
 
+        self._results["plds"] = None
         if "SliceTiming" in metadata:
             # Offset PLD(s) by slice times
             # This step builds a voxel-wise array of post-labeling delay values,
@@ -575,6 +581,7 @@ class ComputeCBF(SimpleInterface):
                 newpath=runtime.cwd,
             )
             pld_img.to_filename(pld_file)
+            self._results["plds"] = pld_file
 
         elif is_multi_pld:
             # Broadcast PLDs to voxels by PLDs

--- a/aslprep/interfaces/cbf.py
+++ b/aslprep/interfaces/cbf.py
@@ -582,7 +582,6 @@ class ComputeCBF(SimpleInterface):
             )
             pld_img.to_filename(pld_file)
             self._results["plds"] = pld_file
-            raise ValueError(pld_file)
 
         elif is_multi_pld:
             # Broadcast PLDs to voxels by PLDs

--- a/aslprep/interfaces/cbf.py
+++ b/aslprep/interfaces/cbf.py
@@ -582,6 +582,7 @@ class ComputeCBF(SimpleInterface):
             )
             pld_img.to_filename(pld_file)
             self._results["plds"] = pld_file
+            raise ValueError(pld_file)
 
         elif is_multi_pld:
             # Broadcast PLDs to voxels by PLDs

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -242,6 +242,7 @@ using the Q2TIPS modification, as described in @noguchi2015technical.
                 "mean_cbf",
                 "cbf_ts",  # Only calculated for single-delay data
                 "att",  # Only calculated for multi-delay data
+                "plds",
                 # SCORE/SCRUB outputs
                 "cbf_ts_score",
                 "mean_cbf_score",
@@ -383,6 +384,7 @@ using the Q2TIPS modification, as described in @noguchi2015technical.
             ("cbf_ts", "cbf_ts"),
             ("mean_cbf", "mean_cbf"),
             ("att", "att"),
+            ("plds", "plds"),
         ]),
     ])
     # fmt:on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pandas >= 0.24.0",
     "patsy",
     "psutil >= 5.4",
-    "pybids >= 0.13.2",
+    "pybids ~= 0.16.4",
     "pyyaml",
     "scipy == 1.10.1",  # 1.11 introduces backwards incompatible change to scipy.stats.mode that doesn't work with bundled SDCFlows
     "sdcflows",


### PR DESCRIPTION
Closes #347.

## Changes proposed in this pull request

- Only use the `--slicedt` argument in BASIL calls when the slice order is ascending.
    - I wonder if this could still be missing some cases (e.g., slice encoding direction that isn't `k`).
- Add `plds` as an output to the `ComputeCBF` interface. This will only be written out when the PLDs are slice-timing corrected.