### PR TITLE
Fix several warnings

### DIFF
--- a/aslprep/cli/workflow.py
+++ b/aslprep/cli/workflow.py
@@ -178,7 +178,7 @@ def build_boilerplate(config_file, workflow):
             "pandoc",
             "-s",
             "--bibliography",
-            load_data.readable("boilerplate.bib"),
+            str(load_data.readable("boilerplate.bib")),
             "--natbib",
             str(citation_files["md"]),
             "-o",

--- a/aslprep/cli/workflow.py
+++ b/aslprep/cli/workflow.py
@@ -63,14 +63,14 @@ def build_workflow(config_file, retval):
 
     # Called with reports only
     if config.execution.reports_only:
-        from pkg_resources import resource_filename as pkgrf
+        from aslprep.data import load as load_data
 
         build_log.log(25, "Running --reports-only on participants %s", ", ".join(subject_list))
         retval["return_code"] = generate_reports(
             subject_list,
             config.execution.aslprep_dir,
             config.execution.run_uuid,
-            config=pkgrf("aslprep", "data/reports-spec.yml"),
+            config=load_data.as_path("reports-spec.yml"),
             packagename="aslprep",
         )
         return retval
@@ -150,14 +150,14 @@ def build_boilerplate(config_file, workflow):
         from shutil import copyfile
         from subprocess import CalledProcessError, TimeoutExpired, check_call
 
-        from pkg_resources import resource_filename as pkgrf
+        from aslprep.data import load as load_data
 
         # Generate HTML file resolving citations
         cmd = [
             "pandoc",
             "-s",
             "--bibliography",
-            pkgrf("aslprep", "data/boilerplate.bib"),
+            load_data.as_path("boilerplate.bib"),
             "--filter",
             "pandoc-citeproc",
             "--metadata",
@@ -178,7 +178,7 @@ def build_boilerplate(config_file, workflow):
             "pandoc",
             "-s",
             "--bibliography",
-            pkgrf("aslprep", "data/boilerplate.bib"),
+            load_data.as_path("boilerplate.bib"),
             "--natbib",
             str(citation_files["md"]),
             "-o",
@@ -190,4 +190,4 @@ def build_boilerplate(config_file, workflow):
         except (FileNotFoundError, CalledProcessError, TimeoutExpired):
             config.loggers.cli.warning("Could not generate CITATION.tex file:\n%s", " ".join(cmd))
         else:
-            copyfile(pkgrf("aslprep", "data/boilerplate.bib"), citation_files["bib"])
+            copyfile(load_data.as_path("boilerplate.bib"), citation_files["bib"])

--- a/aslprep/cli/workflow.py
+++ b/aslprep/cli/workflow.py
@@ -70,7 +70,7 @@ def build_workflow(config_file, retval):
             subject_list,
             config.execution.aslprep_dir,
             config.execution.run_uuid,
-            config=load_data.as_path("reports-spec.yml"),
+            config=load_data.readable("reports-spec.yml"),
             packagename="aslprep",
         )
         return retval
@@ -157,7 +157,7 @@ def build_boilerplate(config_file, workflow):
             "pandoc",
             "-s",
             "--bibliography",
-            load_data.as_path("boilerplate.bib"),
+            load_data.readable("boilerplate.bib"),
             "--filter",
             "pandoc-citeproc",
             "--metadata",
@@ -178,7 +178,7 @@ def build_boilerplate(config_file, workflow):
             "pandoc",
             "-s",
             "--bibliography",
-            load_data.as_path("boilerplate.bib"),
+            load_data.readable("boilerplate.bib"),
             "--natbib",
             str(citation_files["md"]),
             "-o",
@@ -190,4 +190,4 @@ def build_boilerplate(config_file, workflow):
         except (FileNotFoundError, CalledProcessError, TimeoutExpired):
             config.loggers.cli.warning("Could not generate CITATION.tex file:\n%s", " ".join(cmd))
         else:
-            copyfile(load_data.as_path("boilerplate.bib"), citation_files["bib"])
+            copyfile(load_data.readable("boilerplate.bib"), citation_files["bib"])

--- a/aslprep/cli/workflow.py
+++ b/aslprep/cli/workflow.py
@@ -157,7 +157,7 @@ def build_boilerplate(config_file, workflow):
             "pandoc",
             "-s",
             "--bibliography",
-            load_data.readable("boilerplate.bib"),
+            str(load_data("boilerplate.bib")),
             "--filter",
             "pandoc-citeproc",
             "--metadata",

--- a/aslprep/cli/workflow.py
+++ b/aslprep/cli/workflow.py
@@ -70,7 +70,7 @@ def build_workflow(config_file, retval):
             subject_list,
             config.execution.aslprep_dir,
             config.execution.run_uuid,
-            config=load_data.readable("reports-spec.yml"),
+            config=load_data("reports-spec.yml"),
             packagename="aslprep",
         )
         return retval
@@ -178,7 +178,7 @@ def build_boilerplate(config_file, workflow):
             "pandoc",
             "-s",
             "--bibliography",
-            str(load_data.readable("boilerplate.bib")),
+            str(load_data("boilerplate.bib")),
             "--natbib",
             str(citation_files["md"]),
             "-o",
@@ -190,4 +190,4 @@ def build_boilerplate(config_file, workflow):
         except (FileNotFoundError, CalledProcessError, TimeoutExpired):
             config.loggers.cli.warning("Could not generate CITATION.tex file:\n%s", " ".join(cmd))
         else:
-            copyfile(load_data.readable("boilerplate.bib"), citation_files["bib"])
+            copyfile(load_data("boilerplate.bib"), citation_files["bib"])

--- a/aslprep/interfaces/__init__.py
+++ b/aslprep/interfaces/__init__.py
@@ -1,23 +1,26 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Nipype interfaces for aslprep."""
-from aslprep.interfaces.bids import DerivativesDataSink
-from aslprep.interfaces.confounds import GatherConfounds
-from aslprep.interfaces.plotting import ASLCarpetPlot, CBFSummaryPlot
-from aslprep.interfaces.reports import (
-    AboutSummary,
-    CBFSummary,
-    FunctionalSummary,
-    SubjectSummary,
+from aslprep.interfaces import (
+    ants,
+    bids,
+    cbf,
+    confounds,
+    parcellation,
+    plotting,
+    reference,
+    reports,
+    utility,
 )
 
 __all__ = [
-    "AboutSummary",
-    "ASLCarpetPlot",
-    "CBFSummary",
-    "CBFSummaryPlot",
-    "DerivativesDataSink",
-    "FunctionalSummary",
-    "GatherConfounds",
-    "SubjectSummary",
+    "ants",
+    "bids",
+    "cbf",
+    "confounds",
+    "parcellation",
+    "plotting",
+    "reference",
+    "reports",
+    "utility",
 ]

--- a/aslprep/interfaces/bids.py
+++ b/aslprep/interfaces/bids.py
@@ -12,12 +12,12 @@ from nipype.interfaces.base import (
     traits,
 )
 from niworkflows.interfaces.bids import DerivativesDataSink as BaseDerivativesDataSink
-from pkg_resources import resource_filename as pkgrf
 
 from aslprep import config
+from aslprep.data import load as load_data
 
 # NOTE: Modified for aslprep's purposes
-aslprep_spec = loads(Path(pkgrf("aslprep", "data/aslprep_bids_config.json")).read_text())
+aslprep_spec = loads(Path(load_data.as_path("aslprep_bids_config.json")).read_text())
 bids_config = Config.load("bids")
 deriv_config = Config.load("derivatives")
 

--- a/aslprep/interfaces/bids.py
+++ b/aslprep/interfaces/bids.py
@@ -1,6 +1,5 @@
 """Adapted interfaces from Niworkflows."""
 from json import loads
-from pathlib import Path
 
 from bids.layout import Config
 from nipype.interfaces.base import (
@@ -17,7 +16,7 @@ from aslprep import config
 from aslprep.data import load as load_data
 
 # NOTE: Modified for aslprep's purposes
-aslprep_spec = loads(Path(load_data.readable("aslprep_bids_config.json")).read_text())
+aslprep_spec = loads(load_data.readable("aslprep_bids_config.json").read_text())
 bids_config = Config.load("bids")
 deriv_config = Config.load("derivatives")
 

--- a/aslprep/interfaces/bids.py
+++ b/aslprep/interfaces/bids.py
@@ -17,7 +17,7 @@ from aslprep import config
 from aslprep.data import load as load_data
 
 # NOTE: Modified for aslprep's purposes
-aslprep_spec = loads(Path(load_data.as_path("aslprep_bids_config.json")).read_text())
+aslprep_spec = loads(Path(load_data.readable("aslprep_bids_config.json")).read_text())
 bids_config = Config.load("bids")
 deriv_config = Config.load("derivatives")
 

--- a/aslprep/interfaces/parcellation.py
+++ b/aslprep/interfaces/parcellation.py
@@ -95,6 +95,7 @@ class ParcellateCBF(SimpleInterface):
             standardize=False,
             strategy="sum",
             resampling_target=None,  # they should be in the same space/resolution already
+            keep_masked_labels=True,
         )
         sum_masker_unmasked = NiftiLabelsMasker(
             labels_img=atlas,
@@ -103,6 +104,7 @@ class ParcellateCBF(SimpleInterface):
             standardize=False,
             strategy="sum",
             resampling_target=None,  # they should be in the same space/resolution already
+            keep_masked_labels=True,
         )
         n_voxels_in_masked_parcels = sum_masker_masked.fit_transform(atlas_img_bin)
         n_voxels_in_parcels = sum_masker_unmasked.fit_transform(atlas_img_bin)
@@ -150,6 +152,7 @@ class ParcellateCBF(SimpleInterface):
             smoothing_fwhm=None,
             standardize=False,
             resampling_target=None,  # they should be in the same space/resolution already
+            keep_masked_labels=True,
         )
 
         # Use nilearn for time_series

--- a/aslprep/interfaces/plotting.py
+++ b/aslprep/interfaces/plotting.py
@@ -215,12 +215,13 @@ class CBFByTissueTypePlot(SimpleInterface):
             fig, ax = plt.subplots(figsize=(16, 8))
             sns.despine(ax=ax, bottom=True, left=True)
             sns.boxenplot(
-                x="Tissue Type",
                 y="CBF\n(mL/100 g/min)",
                 data=df,
                 width=0.6,
                 showfliers=True,
                 palette={"GM": "#1b60a5", "WM": "#2da467", "CSF": "#9d8f25"},
+                hue="Tissue Type",
+                legend=False,
                 ax=ax,
             )
             fig.tight_layout()

--- a/aslprep/tests/test_cli.py
+++ b/aslprep/tests/test_cli.py
@@ -414,7 +414,7 @@ def _run_and_generate(test_name, participant_label, parameters, out_dir):
         [participant_label],
         out_dir,
         config.execution.run_uuid,
-        config=load_data.readable("reports-spec.yml"),
+        config=load_data("reports-spec.yml"),
         packagename="aslprep",
     )
 

--- a/aslprep/tests/test_cli.py
+++ b/aslprep/tests/test_cli.py
@@ -4,10 +4,10 @@ import os
 import pytest
 from fmriprep.reports.core import generate_reports
 from nipype import config as nipype_config
-from pkg_resources import resource_filename as pkgrf
 
 from aslprep.cli.parser import parse_args
 from aslprep.cli.workflow import build_boilerplate, build_workflow
+from aslprep.data import load as load_data
 from aslprep.tests.utils import (
     check_generated_files,
     download_test_data,
@@ -414,7 +414,7 @@ def _run_and_generate(test_name, participant_label, parameters, out_dir):
         [participant_label],
         out_dir,
         config.execution.run_uuid,
-        config=pkgrf("aslprep", "data/reports-spec.yml"),
+        config=load_data.as_path("reports-spec.yml"),
         packagename="aslprep",
     )
 

--- a/aslprep/tests/test_cli.py
+++ b/aslprep/tests/test_cli.py
@@ -414,7 +414,7 @@ def _run_and_generate(test_name, participant_label, parameters, out_dir):
         [participant_label],
         out_dir,
         config.execution.run_uuid,
-        config=load_data.as_path("reports-spec.yml"),
+        config=load_data.readable("reports-spec.yml"),
         packagename="aslprep",
     )
 

--- a/aslprep/tests/tests.py
+++ b/aslprep/tests/tests.py
@@ -53,7 +53,7 @@ def mock_config():
     config.init_spaces()
 
     config.execution.work_dir = Path(mkdtemp())
-    config.execution.bids_dir = Path(load_data.as_path("../tests/data/ds000240")).absolute()
+    config.execution.bids_dir = Path(load_data.readable("../tests/data/ds000240")).absolute()
     config.execution.aslprep_dir = Path(mkdtemp())
     config.execution.init()
 

--- a/aslprep/tests/tests.py
+++ b/aslprep/tests/tests.py
@@ -53,7 +53,7 @@ def mock_config():
     config.init_spaces()
 
     config.execution.work_dir = Path(mkdtemp())
-    config.execution.bids_dir = Path(load_data.readable("../tests/data/ds000240")).absolute()
+    config.execution.bids_dir = load_data.readable("../tests/data/ds000240").absolute()
     config.execution.aslprep_dir = Path(mkdtemp())
     config.execution.init()
 

--- a/aslprep/tests/tests.py
+++ b/aslprep/tests/tests.py
@@ -27,8 +27,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from tempfile import mkdtemp
 
-from pkg_resources import resource_filename as pkgrf
 from toml import loads
+
+from aslprep.data import load as load_data
 
 
 @contextmanager
@@ -40,7 +41,7 @@ def mock_config():
     if not _old_fs:
         os.environ["FREESURFER_HOME"] = mkdtemp()
 
-    filename = Path(pkgrf("aslprep", "tests/data/config.toml"))
+    filename = Path(load_data("../tests/data/config.toml"))
     settings = loads(filename.read_text())
     for sectionname, configs in settings.items():
         if sectionname != "environment":
@@ -52,7 +53,7 @@ def mock_config():
     config.init_spaces()
 
     config.execution.work_dir = Path(mkdtemp())
-    config.execution.bids_dir = Path(pkgrf("aslprep", "tests/data/ds000240")).absolute()
+    config.execution.bids_dir = Path(load_data.as_path("../tests/data/ds000240")).absolute()
     config.execution.aslprep_dir = Path(mkdtemp())
     config.execution.init()
 

--- a/aslprep/tests/tests.py
+++ b/aslprep/tests/tests.py
@@ -53,7 +53,7 @@ def mock_config():
     config.init_spaces()
 
     config.execution.work_dir = Path(mkdtemp())
-    config.execution.bids_dir = load_data.readable("../tests/data/ds000240").absolute()
+    config.execution.bids_dir = load_data("../tests/data/ds000240").absolute()
     config.execution.aslprep_dir = Path(mkdtemp())
     config.execution.init()
 

--- a/aslprep/utils/__init__.py
+++ b/aslprep/utils/__init__.py
@@ -1,1 +1,24 @@
 """Utility functions for aslprep."""
+from aslprep.utils import (
+    asl,
+    atlas,
+    bids,
+    cbf,
+    confounds,
+    misc,
+    plotting,
+    sentry,
+    spaces,
+)
+
+__all__ = [
+    "asl",
+    "atlas",
+    "bids",
+    "cbf",
+    "confounds",
+    "misc",
+    "plotting",
+    "sentry",
+    "spaces",
+]

--- a/aslprep/utils/atlas.py
+++ b/aslprep/utils/atlas.py
@@ -88,11 +88,11 @@ def get_atlas_nifti(atlas_name):
         atlas_labels_file = join("/AtlasPack", tsv_fname)
         atlas_metadata_file = f"/AtlasPack/tpl-MNI152NLin6Asym_atlas-{atlas_name}_dseg.json"
     else:
-        atlas_file = load_data.readable(f"atlases/{atlas_fname}")
-        atlas_labels_file = load_data.readable(f"atlases/{tsv_fname}")
+        atlas_file = load_data.readable(f"atlases/{atlas_fname}").absolute()
+        atlas_labels_file = load_data.readable(f"atlases/{tsv_fname}").absolute()
         atlas_metadata_file = load_data.readable(
             f"atlases/tpl-MNI152NLin6Asym_atlas-{atlas_name}_dseg.json",
-        )
+        ).absolute()
 
     if not (isfile(atlas_file) and isfile(atlas_labels_file) and isfile(atlas_metadata_file)):
         raise FileNotFoundError(

--- a/aslprep/utils/atlas.py
+++ b/aslprep/utils/atlas.py
@@ -47,7 +47,7 @@ def get_atlas_names(subset):
 
 
 def get_atlas_nifti(atlas_name):
-    """Select atlas by name from aslprep/data using pkgrf.
+    """Select atlas by name from aslprep/data using aslprep.data.load.
 
     All atlases are in MNI space.
 
@@ -72,7 +72,7 @@ def get_atlas_nifti(atlas_name):
     """
     from os.path import isfile, join
 
-    from pkg_resources import resource_filename as pkgrf
+    from aslprep.data import load as load_data
 
     if "4S" in atlas_name or atlas_name in ("Glasser", "Gordon"):
         # 1 mm3 atlases
@@ -88,11 +88,10 @@ def get_atlas_nifti(atlas_name):
         atlas_labels_file = join("/AtlasPack", tsv_fname)
         atlas_metadata_file = f"/AtlasPack/tpl-MNI152NLin6Asym_atlas-{atlas_name}_dseg.json"
     else:
-        atlas_file = pkgrf("aslprep", f"data/atlases/{atlas_fname}")
-        atlas_labels_file = pkgrf("aslprep", f"data/atlases/{tsv_fname}")
-        atlas_metadata_file = pkgrf(
-            "aslprep",
-            f"data/atlases/tpl-MNI152NLin6Asym_atlas-{atlas_name}_dseg.json",
+        atlas_file = load_data.as_path(f"atlases/{atlas_fname}")
+        atlas_labels_file = load_data.as_path(f"atlases/{tsv_fname}")
+        atlas_metadata_file = load_data.as_path(
+            f"atlases/tpl-MNI152NLin6Asym_atlas-{atlas_name}_dseg.json",
         )
 
     if not (isfile(atlas_file) and isfile(atlas_labels_file) and isfile(atlas_metadata_file)):

--- a/aslprep/utils/atlas.py
+++ b/aslprep/utils/atlas.py
@@ -88,9 +88,9 @@ def get_atlas_nifti(atlas_name):
         atlas_labels_file = join("/AtlasPack", tsv_fname)
         atlas_metadata_file = f"/AtlasPack/tpl-MNI152NLin6Asym_atlas-{atlas_name}_dseg.json"
     else:
-        atlas_file = load_data.as_path(f"atlases/{atlas_fname}")
-        atlas_labels_file = load_data.as_path(f"atlases/{tsv_fname}")
-        atlas_metadata_file = load_data.as_path(
+        atlas_file = load_data.readable(f"atlases/{atlas_fname}")
+        atlas_labels_file = load_data.readable(f"atlases/{tsv_fname}")
+        atlas_metadata_file = load_data.readable(
             f"atlases/tpl-MNI152NLin6Asym_atlas-{atlas_name}_dseg.json",
         )
 

--- a/aslprep/utils/atlas.py
+++ b/aslprep/utils/atlas.py
@@ -88,9 +88,9 @@ def get_atlas_nifti(atlas_name):
         atlas_labels_file = join("/AtlasPack", tsv_fname)
         atlas_metadata_file = f"/AtlasPack/tpl-MNI152NLin6Asym_atlas-{atlas_name}_dseg.json"
     else:
-        atlas_file = load_data.readable(f"atlases/{atlas_fname}").absolute()
-        atlas_labels_file = load_data.readable(f"atlases/{tsv_fname}").absolute()
-        atlas_metadata_file = load_data.readable(
+        atlas_file = load_data(f"atlases/{atlas_fname}").absolute()
+        atlas_labels_file = load_data(f"atlases/{tsv_fname}").absolute()
+        atlas_metadata_file = load_data(
             f"atlases/tpl-MNI152NLin6Asym_atlas-{atlas_name}_dseg.json",
         ).absolute()
 

--- a/aslprep/utils/cbf.py
+++ b/aslprep/utils/cbf.py
@@ -461,7 +461,7 @@ def _scrubcbf(cbf_ts, gm, wm, csf, mask, wfun="huber", thresh=0.7):
     X[:, 0] = gm.flatten()[gm.flatten() >= (0)] * idxx
     X[:, 1] = wm.flatten()[wm.flatten() >= (0)] * idxx
     A = (mean_cbf.flatten()[idxx >= 0]) * idxx
-    c = np.linalg.lstsq(X, A)[0]
+    c = np.linalg.lstsq(X, A, rcond=None)[0]
     Globalpriorfull = c[0] * gm.flatten() + c[1] * wm.flatten()
     Globalprior = Globalpriorfull[mask.flatten() == 1]
     localprior = 0

--- a/aslprep/workflows/asl/__init__.py
+++ b/aslprep/workflows/asl/__init__.py
@@ -1,11 +1,30 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Workflows for the ASL processing portions of ASLPrep."""
-from aslprep.workflows.asl import base, cbf, confounds, hmc
+from aslprep.workflows.asl import (
+    apply,
+    base,
+    cbf,
+    confounds,
+    fit,
+    hmc,
+    outputs,
+    plotting,
+    reference,
+    resampling,
+    util,
+)
 
 __all__ = [
+    "apply",
     "base",
     "cbf",
     "confounds",
+    "fit",
     "hmc",
+    "outputs",
+    "plotting",
+    "reference",
+    "resampling",
+    "util",
 ]

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -681,7 +681,7 @@ or the whole parcel was set to zero (when the parcel had <{min_coverage * 100}% 
     atlas_name_grabber.inputs.subset = "all"
     workflow.connect([(atlas_name_grabber, outputnode, [("atlas_names", "atlas_names")])])
 
-    # get atlases via pkgrf
+    # get atlases via aslprep.data.load
     atlas_file_grabber = pe.MapNode(
         niu.Function(
             input_names=["atlas_name"],

--- a/aslprep/workflows/asl/outputs.py
+++ b/aslprep/workflows/asl/outputs.py
@@ -9,8 +9,8 @@ from niworkflows.utils.images import dseg_label
 from smriprep.workflows.outputs import _bids_relative
 
 from aslprep import config
-from aslprep.interfaces import DerivativesDataSink
 from aslprep.interfaces.ants import ApplyTransforms
+from aslprep.interfaces.bids import DerivativesDataSink
 
 BASE_INPUT_FIELDS = {
     "asl": {

--- a/aslprep/workflows/asl/plotting.py
+++ b/aslprep/workflows/asl/plotting.py
@@ -6,8 +6,8 @@ from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
 from aslprep import config
-from aslprep.interfaces import DerivativesDataSink
 from aslprep.interfaces.ants import ApplyTransforms
+from aslprep.interfaces.bids import DerivativesDataSink
 from aslprep.interfaces.confounds import GatherCBFConfounds
 from aslprep.interfaces.plotting import CBFByTissueTypePlot, CBFSummaryPlot
 from aslprep.interfaces.reports import CBFSummary

--- a/aslprep/workflows/base.py
+++ b/aslprep/workflows/base.py
@@ -13,8 +13,8 @@ from niworkflows.utils.connections import listify
 from packaging.version import Version
 
 from aslprep import config
-from aslprep.interfaces import AboutSummary, DerivativesDataSink, SubjectSummary
-from aslprep.interfaces.bids import BIDSDataGrabber
+from aslprep.interfaces.bids import BIDSDataGrabber, DerivativesDataSink
+from aslprep.interfaces.reports import AboutSummary, SubjectSummary
 from aslprep.utils.misc import _prefix
 from aslprep.workflows.asl.base import init_asl_wf
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -83,3 +83,19 @@ Internal configuration system
    aslprep.utils.plotting
    aslprep.utils.sentry
    aslprep.utils.spaces
+
+***********************************
+:mod:`aslprep.data`: Data resources
+***********************************
+
+.. automodule:: aslprep.data
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: aslprep
+
+.. autosummary::
+   :toctree: generated/
+   :template: module.rst
+
+   aslprep.data

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -266,7 +266,7 @@ CBF Computation in native space
    from aslprep.data import load as load_data
    from aslprep.workflows.asl.cbf import init_cbf_wf
 
-   bids_dir = Path(load_data.as_path("../tests/data/ds000240")).absolute()
+   bids_dir = Path(load_data.readable("../tests/data/ds000240")).absolute()
    nii_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.nii.gz"
    metadata_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.json"
    with open(metadata_file) as f:
@@ -618,7 +618,7 @@ Quality control measures
    from aslprep.data import load as load_data
    from aslprep.workflows.asl.qc import init_cbf_confounds_wf
 
-   bids_dir = Path(load_data.as_path("../tests/data/ds000240")).absolute()
+   bids_dir = Path(load_data.readable("../tests/data/ds000240")).absolute()
    asl_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.nii.gz"
    metadata = bids_dir / "sub-01" / "perf"/ "sub-01_asl.json"
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -266,7 +266,7 @@ CBF Computation in native space
    from aslprep.data import load as load_data
    from aslprep.workflows.asl.cbf import init_cbf_wf
 
-   bids_dir = Path(load_data.readable("../tests/data/ds000240")).absolute()
+   bids_dir = load_data.readable("../tests/data/ds000240").absolute()
    nii_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.nii.gz"
    metadata_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.json"
    with open(metadata_file) as f:
@@ -618,7 +618,7 @@ Quality control measures
    from aslprep.data import load as load_data
    from aslprep.workflows.asl.qc import init_cbf_confounds_wf
 
-   bids_dir = Path(load_data.readable("../tests/data/ds000240")).absolute()
+   bids_dir = load_data.readable("../tests/data/ds000240").absolute()
    asl_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.nii.gz"
    metadata = bids_dir / "sub-01" / "perf"/ "sub-01_asl.json"
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -262,11 +262,11 @@ CBF Computation in native space
 
    import json
    from pathlib import Path
-   from pkg_resources import resource_filename as pkgrf
 
+   from aslprep.data import load as load_data
    from aslprep.workflows.asl.cbf import init_cbf_wf
 
-   bids_dir = Path(pkgrf("aslprep", "tests/data/ds000240")).absolute()
+   bids_dir = Path(load_data.as_path("../tests/data/ds000240")).absolute()
    nii_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.nii.gz"
    metadata_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.json"
    with open(metadata_file) as f:
@@ -614,11 +614,11 @@ Quality control measures
    :simple_form: yes
 
    from pathlib import Path
-   from pkg_resources import resource_filename as pkgrf
 
+   from aslprep.data import load as load_data
    from aslprep.workflows.asl.qc import init_cbf_confounds_wf
 
-   bids_dir = Path(pkgrf("aslprep", "tests/data/ds000240")).absolute()
+   bids_dir = Path(load_data.as_path("../tests/data/ds000240")).absolute()
    asl_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.nii.gz"
    metadata = bids_dir / "sub-01" / "perf"/ "sub-01_asl.json"
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -266,7 +266,7 @@ CBF Computation in native space
    from aslprep.data import load as load_data
    from aslprep.workflows.asl.cbf import init_cbf_wf
 
-   bids_dir = load_data.readable("../tests/data/ds000240").absolute()
+   bids_dir = load_data("../tests/data/ds000240").absolute()
    nii_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.nii.gz"
    metadata_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.json"
    with open(metadata_file) as f:
@@ -618,7 +618,7 @@ Quality control measures
    from aslprep.data import load as load_data
    from aslprep.workflows.asl.qc import init_cbf_confounds_wf
 
-   bids_dir = load_data.readable("../tests/data/ds000240").absolute()
+   bids_dir = load_data("../tests/data/ds000240").absolute()
    asl_file = bids_dir / "sub-01" / "perf"/ "sub-01_asl.nii.gz"
    metadata = bids_dir / "sub-01" / "perf"/ "sub-01_asl.json"
 


### PR DESCRIPTION
Closes none, but works on #344.

## Changes proposed in this pull request

- Replace `pkg_resources` with `aslprep.data.load`.
- Add `rcond` to `numpy.linalg.lstsq` calls.
- Properly use `hue` in seaborn calls.
- Set `keep_masked_labels` to `True` in `NiftiLabelsMasker` calls.
    - This change will raise an error in Nilearn 0.15, but that will make it easier to detect and fix.