### PR TITLE
Fix fMRIPrep-related bugs

### DIFF
--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -21,6 +21,7 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Fit workflows for ASLPrep."""
+import os
 import typing as ty
 
 import bids
@@ -201,6 +202,14 @@ def init_asl_fit_wf(
         entity_overrides=config.execution.get().get("bids_filters", {}).get("sbref", {}),
         layout=layout,
     )
+    basename = os.path.basename(asl_file)
+    sbref_msg = f"No single-band-reference found for {basename}."
+    if sbref_file and "sbref" in config.workflow.ignore:
+        sbref_msg = f"Single-band reference file(s) found for {basename} and ignored."
+        sbref_file = []
+    elif sbref_file:
+        sbref_msg = f"Using single-band reference file(s) {os.path.basename(sbref_file)}."
+    config.loggers.workflow.info(sbref_msg)
 
     # Get metadata from ASL file(s)
     metadata = layout.get_metadata(asl_file)

--- a/aslprep/workflows/asl/resampling.py
+++ b/aslprep/workflows/asl/resampling.py
@@ -295,6 +295,9 @@ def init_bold_fsLR_resampling_wf(  # noqa: N802
 ):
     """Resample BOLD time series to fsLR surface.
 
+    This is copied from fMRIPrep and can be replaced with an fMRIPrep import once 23.2.0 is
+    released.
+
     This workflow is derived heavily from three scripts within the DCAN-HCP pipelines scripts
 
     Line numbers correspond to the locations of the code in the original scripts, found at:
@@ -426,8 +429,8 @@ The BOLD time-series were resampled onto the left/right-symmetric template
     ]
     atlases = smriprep_data.load_resource("atlases")
     select_surfaces.inputs.template_roi = [
-        str(atlases / "L.atlasroi.32k_fs_LR.shape.gii"),
-        str(atlases / "R.atlasroi.32k_fs_LR.shape.gii"),
+        str(atlases / f"L.atlasroi.{fslr_density}_fs_LR.shape.gii"),
+        str(atlases / f"R.atlasroi.{fslr_density}_fs_LR.shape.gii"),
     ]
 
     # RibbonVolumeToSurfaceMapping.sh


### PR DESCRIPTION
Closes none, but addresses ASLPrep's copy of multiple 23.2.0a2-related fMRIPrep bugs.

## Changes proposed in this pull request

- Fix CIFTI density bug (https://github.com/nipreps/fmriprep/pull/3179)
- Ignore sbrefs when requested (https://github.com/nipreps/fmriprep/pull/3180)
    - Technically, sbrefs aren't supported for ASL data yet, so this won't change behavior.