### PR TITLE
Rename QC metrics and output QC files as TSVs

### DIFF
--- a/aslprep/cli/aggregate_qc.py
+++ b/aslprep/cli/aggregate_qc.py
@@ -33,9 +33,9 @@ def main():
             if filex.endswith("desc-qualitycontrol_cbf.tsv"):
                 qclist.append(r + "/" + filex)
 
-    datax = pd.read_csv(qclist[0])
+    datax = pd.read_table(qclist[0])
     for i in range(1, len(qclist)):
-        dy = pd.read_csv(qclist[i])
+        dy = pd.read_table(qclist[i])
         datax = pd.concat([datax, dy])
 
     datax.to_csv(outputfile, index=None, sep="\t")

--- a/aslprep/cli/aggregate_qc.py
+++ b/aslprep/cli/aggregate_qc.py
@@ -25,12 +25,12 @@ def main():
     opts = get_parser().parse_args()
 
     allsubj_dir = os.path.abspath(opts.aslprep_dir)
-    outputfile = os.getcwd() + "/" + str(opts.output_prefix) + "_allsubjects_qc.csv"
+    outputfile = os.getcwd() + "/" + str(opts.output_prefix) + "_allsubjects_qc.tsv"
 
     qclist = []
     for r, d, f in os.walk(allsubj_dir):
         for filex in f:
-            if filex.endswith("quality_control_cbf.csv"):
+            if filex.endswith("desc-qualitycontrol_cbf.tsv"):
                 qclist.append(r + "/" + filex)
 
     datax = pd.read_csv(qclist[0])
@@ -38,7 +38,7 @@ def main():
         dy = pd.read_csv(qclist[i])
         datax = pd.concat([datax, dy])
 
-    datax.to_csv(outputfile, index=None)
+    datax.to_csv(outputfile, index=None, sep="\t")
 
 
 if __name__ == "__main__":

--- a/aslprep/interfaces/confounds.py
+++ b/aslprep/interfaces/confounds.py
@@ -532,11 +532,11 @@ class ComputeCBFQC(SimpleInterface):
 
         self._results["qc_file"] = fname_presuffix(
             self.inputs.mean_cbf,
-            suffix="qc_cbf.csv",
+            suffix="qc_cbf.tsv",
             newpath=runtime.cwd,
             use_ext=False,
         )
-        qc_df.to_csv(self._results["qc_file"], index=False, header=True, na_rep="n/a")
+        qc_df.to_csv(self._results["qc_file"], index=False, header=True, sep="\t", na_rep="n/a")
 
         self._results["qc_metadata"] = fname_presuffix(
             self.inputs.mean_cbf,

--- a/aslprep/interfaces/confounds.py
+++ b/aslprep/interfaces/confounds.py
@@ -22,7 +22,6 @@ from aslprep.utils.confounds import (
     average_cbf_by_tissue,
     compute_qei,
     dice,
-    jaccard,
     negativevoxel,
     overlap,
     pearson,
@@ -207,19 +206,17 @@ class ComputeCBFQC(SimpleInterface):
         asl_mask_arr = nb.load(self.inputs.asl_mask).get_fdata()
         t1w_mask_arr = nb.load(self.inputs.t1w_mask).get_fdata()
         coreg_dice = dice(asl_mask_arr, t1w_mask_arr)
-        coreg_jaccard = jaccard(asl_mask_arr, t1w_mask_arr)
-        coreg_crosscorr = pearson(asl_mask_arr, t1w_mask_arr)
-        coreg_coverage = overlap(asl_mask_arr, t1w_mask_arr)
+        coreg_correlation = pearson(asl_mask_arr, t1w_mask_arr)
+        coreg_overlap = overlap(asl_mask_arr, t1w_mask_arr)
 
         if self.inputs.asl_mask_std and self.inputs.template_mask:
             asl_mask_std_arr = nb.load(self.inputs.asl_mask_std).get_fdata()
             template_mask_arr = nb.load(self.inputs.template_mask).get_fdata()
             norm_dice = dice(asl_mask_std_arr, template_mask_arr)
-            norm_jaccard = jaccard(asl_mask_std_arr, template_mask_arr)
-            norm_crosscorr = pearson(asl_mask_std_arr, template_mask_arr)
-            norm_coverage = overlap(asl_mask_std_arr, template_mask_arr)
+            norm_correlation = pearson(asl_mask_std_arr, template_mask_arr)
+            norm_overlap = overlap(asl_mask_std_arr, template_mask_arr)
 
-        mean_cbf_qei = compute_qei(
+        qei_cbf = compute_qei(
             gm=self.inputs.gm_tpm,
             wm=self.inputs.wm_tpm,
             csf=self.inputs.csf_tpm,
@@ -235,100 +232,99 @@ class ComputeCBFQC(SimpleInterface):
         )
 
         if self.inputs.mean_cbf_score:
-            mean_cbf_score_qei = compute_qei(
+            qei_cbf_score = compute_qei(
                 gm=self.inputs.gm_tpm,
                 wm=self.inputs.wm_tpm,
                 csf=self.inputs.csf_tpm,
                 img=self.inputs.mean_cbf_score,
                 thresh=thresh,
             )
-            mean_cbf_scrub_qei = compute_qei(
+            qei_cbf_scrub = compute_qei(
                 gm=self.inputs.gm_tpm,
                 wm=self.inputs.wm_tpm,
                 csf=self.inputs.csf_tpm,
                 img=self.inputs.mean_cbf_scrub,
                 thresh=thresh,
             )
-            mean_cbf_score_negvox = negativevoxel(
+            percentage_negative_cbf_score = negativevoxel(
                 cbf=self.inputs.mean_cbf_score,
                 gm=self.inputs.gm_tpm,
                 thresh=thresh,
             )
-            mean_cbf_scrub_negvox = negativevoxel(
+            percentage_negative_cbf_scrub = negativevoxel(
                 cbf=self.inputs.mean_cbf_scrub,
                 gm=self.inputs.gm_tpm,
                 thresh=thresh,
             )
         else:
             print("no score inputs, setting to np.nan")
-            mean_cbf_score_qei = np.nan
-            mean_cbf_scrub_qei = np.nan
-            mean_cbf_score_negvox = np.nan
-            mean_cbf_scrub_negvox = np.nan
+            qei_cbf_score = np.nan
+            qei_cbf_scrub = np.nan
+            percentage_negative_cbf_score = np.nan
+            percentage_negative_cbf_scrub = np.nan
 
         if self.inputs.mean_cbf_basil:
-            mean_cbf_basil_qei = compute_qei(
+            qei_cbf_basil = compute_qei(
                 gm=self.inputs.gm_tpm,
                 wm=self.inputs.wm_tpm,
                 csf=self.inputs.csf_tpm,
                 img=self.inputs.mean_cbf_basil,
                 thresh=thresh,
             )
-            mean_cbf_gm_basil_qei = compute_qei(
+            qei_cbf_basil_gm = compute_qei(
                 gm=self.inputs.gm_tpm,
                 wm=self.inputs.wm_tpm,
                 csf=self.inputs.csf_tpm,
                 img=self.inputs.mean_cbf_gm_basil,
                 thresh=thresh,
             )
-            mean_cbf_basil_negvox = negativevoxel(
+            percentage_negative_cbf_basil = negativevoxel(
                 cbf=self.inputs.mean_cbf_basil,
                 gm=self.inputs.gm_tpm,
                 thresh=thresh,
             )
-            mean_cbf_gm_basil_negvox = negativevoxel(
+            percentage_negative_cbf_basil_gm = negativevoxel(
                 cbf=self.inputs.mean_cbf_gm_basil,
                 gm=self.inputs.gm_tpm,
                 thresh=thresh,
             )
         else:
             print("no basil inputs, setting to np.nan")
-            mean_cbf_basil_qei = np.nan
-            mean_cbf_gm_basil_qei = np.nan
-            mean_cbf_basil_negvox = np.nan
-            mean_cbf_gm_basil_negvox = np.nan
+            qei_cbf_basil = np.nan
+            qei_cbf_basil_gm = np.nan
+            percentage_negative_cbf_basil = np.nan
+            percentage_negative_cbf_basil_gm = np.nan
 
-        gm_wm_ratio = np.divide(mean_cbf_mean[0], mean_cbf_mean[1])
-        mean_cbf_negvox = negativevoxel(
+        ratio_gm_wm_cbf = np.divide(mean_cbf_mean[0], mean_cbf_mean[1])
+        percentage_negative_cbf = negativevoxel(
             cbf=self.inputs.mean_cbf,
             gm=self.inputs.gm_tpm,
             thresh=thresh,
         )
 
         metrics_dict = {
-            "FD": [mean_fd],
+            "mean_fd": [mean_fd],
             "rmsd": [mean_rms],
-            "coregDC": [coreg_dice],
-            "coregJC": [coreg_jaccard],
-            "coregCC": [coreg_crosscorr],
-            "coregCOV": [coreg_coverage],
-            "cbfQEI": [mean_cbf_qei],
-            "scoreQEI": [mean_cbf_score_qei],
-            "scrubQEI": [mean_cbf_scrub_qei],
-            "basilQEI": [mean_cbf_basil_qei],
-            "pvcQEI": [mean_cbf_gm_basil_qei],
-            "GMmeanCBF": [mean_cbf_mean[0]],
-            "WMmeanCBF": [mean_cbf_mean[1]],
-            "Gm_Wm_CBF_ratio": [gm_wm_ratio],
-            "NEG_CBF_PERC": [mean_cbf_negvox],
-            "NEG_SCORE_PERC": [mean_cbf_score_negvox],
-            "NEG_SCRUB_PERC": [mean_cbf_scrub_negvox],
-            "NEG_BASIL_PERC": [mean_cbf_basil_negvox],
-            "NEG_PVC_PERC": [mean_cbf_gm_basil_negvox],
+            "coreg_dice": [coreg_dice],
+            "coreg_correlation": [coreg_correlation],
+            "coreg_overlap": [coreg_overlap],
+            "qei_cbf": [qei_cbf],
+            "qei_cbf_score": [qei_cbf_score],
+            "qei_cbf_scrub": [qei_cbf_scrub],
+            "qei_cbf_basil": [qei_cbf_basil],
+            "qei_cbf_basil_gm": [qei_cbf_basil_gm],
+            "mean_gm_cbf": [mean_cbf_mean[0]],
+            "mean_wm_cbf": [mean_cbf_mean[1]],
+            "ratio_gm_wm_cbf": [ratio_gm_wm_cbf],
+            "percentage_negative_cbf": [percentage_negative_cbf],
+            "percentage_negative_cbf_score": [percentage_negative_cbf_score],
+            "percentage_negative_cbf_scrub": [percentage_negative_cbf_scrub],
+            "percentage_negative_cbf_basil": [percentage_negative_cbf_basil],
+            "percentage_negative_cbf_basil_gm": [percentage_negative_cbf_basil_gm],
         }
 
         qc_metadata = {
-            "FD": {
+            "mean_fd": {
                 "LongName": "Mean Framewise Displacement",
                 "Description": (
                     "Average framewise displacement without any motion parameter filtering. "
@@ -347,7 +343,7 @@ class ComputeCBFQC(SimpleInterface):
                 ),
                 "Units": "arbitrary",
             },
-            "coregDC": {
+            "coreg_dice": {
                 "LongName": "Coregistration Sørensen-Dice Coefficient",
                 "Description": (
                     "The Sørensen-Dice coefficient calculated between the binary brain masks from "
@@ -357,7 +353,7 @@ class ComputeCBFQC(SimpleInterface):
                 ),
                 "Term URL": "https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient",
             },
-            "coregJC": {
+            "coreg_jaccard": {
                 "LongName": "Coregistration Jaccard Index",
                 "Description": (
                     "The Jaccard index calculated between the binary brain masks from "
@@ -367,7 +363,7 @@ class ComputeCBFQC(SimpleInterface):
                 ),
                 "Term URL": "https://en.wikipedia.org/wiki/Jaccard_index",
             },
-            "coregCC": {
+            "coreg_correlation": {
                 "LongName": "Coregistration Pearson Correlation",
                 "Description": (
                     "The Pearson correlation coefficient calculated between the binary brain "
@@ -377,7 +373,7 @@ class ComputeCBFQC(SimpleInterface):
                 ),
                 "Term URL": "https://en.wikipedia.org/wiki/Pearson_correlation_coefficient",
             },
-            "coregCOV": {
+            "coreg_overlap": {
                 "LongName": "Coregistration Overlap Coefficient",
                 "Description": (
                     "The Szymkiewicz-Simpson overlap coefficient calculated between the binary "
@@ -386,27 +382,27 @@ class ComputeCBFQC(SimpleInterface):
                 ),
                 "Term URL": "https://en.wikipedia.org/wiki/Overlap_coefficient",
             },
-            "cbfQEI": {
+            "qei_cbf": {
                 "LongName": "Cerebral Blood Flow Quality Evaluation Index",
                 "Description": "QEI calculated on mean CBF image.",
                 "Term URL": "http://indexsmart.mirasmart.com/ISMRM2017/PDFfiles/0682.html",
             },
-            "scoreQEI": {
+            "qei_cbf_score": {
                 "LongName": "SCORE-Denoised Cerebral Blood Flow Quality Evaluation Index",
                 "Description": "QEI calculated on mean SCORE-denoised CBF image.",
                 "Term URL": "http://indexsmart.mirasmart.com/ISMRM2017/PDFfiles/0682.html",
             },
-            "scrubQEI": {
+            "qei_cbf_scrub": {
                 "LongName": "SCRUB-Denoised Cerebral Blood Flow Quality Evaluation Index",
                 "Description": "QEI calculated on mean SCRUB-denoised CBF image.",
                 "Term URL": "http://indexsmart.mirasmart.com/ISMRM2017/PDFfiles/0682.html",
             },
-            "basilQEI": {
+            "qei_cbf_basil": {
                 "LongName": "BASIL Cerebral Blood Flow Quality Evaluation Index",
                 "Description": "QEI calculated on CBF image produced by BASIL.",
                 "Term URL": "http://indexsmart.mirasmart.com/ISMRM2017/PDFfiles/0682.html",
             },
-            "pvcQEI": {
+            "qei_cbf_basil_gm": {
                 "LongName": (
                     "BASIL Partial Volume Corrected Cerebral Blood Flow Quality Evaluation Index"
                 ),
@@ -415,30 +411,30 @@ class ComputeCBFQC(SimpleInterface):
                 ),
                 "Term URL": "http://indexsmart.mirasmart.com/ISMRM2017/PDFfiles/0682.html",
             },
-            "GMmeanCBF": {
+            "mean_gm_cbf": {
                 "LongName": "Mean Cerebral Blood Flow of Gray Matter",
                 "Description": "Mean CBF value of gray matter.",
                 "Units": "mL/100 g/min",
             },
-            "WMmeanCBF": {
+            "mean_wm_cbf": {
                 "LongName": "Mean Cerebral Blood Flow of White Matter",
                 "Description": "Mean CBF value of white matter.",
                 "Units": "mL/100 g/min",
             },
-            "Gm_Wm_CBF_ratio": {
+            "ratio_gm_wm_cbf": {
                 "LongName": "Mean Gray Matter-White Matter Cerebral Blood Flow Ratio",
                 "Description": (
                     "The ratio between the mean gray matter and mean white matter CBF values."
                 ),
             },
-            "NEG_CBF_PERC": {
+            "percentage_negative_cbf": {
                 "LongName": "Percentage of Negative Cerebral Blood Flow Values",
                 "Description": (
                     "Percentage of negative CBF values, calculated on the mean CBF image."
                 ),
                 "Units": "percent",
             },
-            "NEG_SCORE_PERC": {
+            "percentage_negative_cbf_score": {
                 "LongName": "Percentage of Negative SCORE-Denoised Cerebral Blood Flow Values",
                 "Description": (
                     "Percentage of negative CBF values, calculated on the SCORE-denoised "
@@ -446,7 +442,7 @@ class ComputeCBFQC(SimpleInterface):
                 ),
                 "Units": "percent",
             },
-            "NEG_SCRUB_PERC": {
+            "percentage_negative_cbf_scrub": {
                 "LongName": "Percentage of Negative SCRUB-Denoised Cerebral Blood Flow Values",
                 "Description": (
                     "Percentage of negative CBF values, calculated on the SCRUB-denoised "
@@ -454,14 +450,14 @@ class ComputeCBFQC(SimpleInterface):
                 ),
                 "Units": "percent",
             },
-            "NEG_BASIL_PERC": {
+            "percentage_negative_cbf_basil": {
                 "LongName": "Percentage of Negative BASIL Cerebral Blood Flow Values",
                 "Description": (
                     "Percentage of negative CBF values, calculated on CBF image produced by BASIL."
                 ),
                 "Units": "percent",
             },
-            "NEG_PVC_PERC": {
+            "percentage_negative_cbf_basil_gm": {
                 "LongName": (
                     "Percentage of Negative BASIL Partial Volume Corrected Cerebral Blood Flow "
                     "Values"
@@ -477,16 +473,15 @@ class ComputeCBFQC(SimpleInterface):
         if self.inputs.asl_mask_std and self.inputs.template_mask:
             metrics_dict.update(
                 {
-                    "normDC": [norm_dice],
-                    "normJC": [norm_jaccard],
-                    "normCC": [norm_crosscorr],
-                    "normCOV": [norm_coverage],
+                    "norm_dice": [norm_dice],
+                    "norm_correlation": [norm_correlation],
+                    "norm_overlap": [norm_overlap],
                 }
             )
 
             qc_metadata.update(
                 {
-                    "normDC": {
+                    "norm_dice": {
                         "LongName": "Normalization Sørensen-Dice Coefficient",
                         "Description": (
                             "The Sørensen-Dice coefficient calculated between the binary brain "
@@ -499,17 +494,7 @@ class ComputeCBFQC(SimpleInterface):
                             "https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient"
                         ),
                     },
-                    "normJC": {
-                        "LongName": "Normalization Jaccard Index",
-                        "Description": (
-                            "The Jaccard index calculated between the binary brain masks from the "
-                            "normalized ASL reference image and the associated template. "
-                            "Values are bounded between 0 and 1, "
-                            "with higher values indicating better normalization."
-                        ),
-                        "Term URL": "https://en.wikipedia.org/wiki/Jaccard_index",
-                    },
-                    "normCC": {
+                    "norm_correlation": {
                         "LongName": "Normalization Pearson Correlation",
                         "Description": (
                             "The Pearson correlation coefficient calculated between the binary "
@@ -522,7 +507,7 @@ class ComputeCBFQC(SimpleInterface):
                             "https://en.wikipedia.org/wiki/Pearson_correlation_coefficient"
                         ),
                     },
-                    "normCOV": {
+                    "norm_overlap": {
                         "LongName": "Normalization Overlap Coefficient",
                         "Description": (
                             "The Szymkiewicz-Simpson overlap coefficient calculated between the "

--- a/aslprep/interfaces/plotting.py
+++ b/aslprep/interfaces/plotting.py
@@ -83,9 +83,8 @@ class ASLCarpetPlot(SimpleInterface):
             else:
                 dataset, segments = cifti_data, cifti_segments
 
-        dataframe = pd.read_csv(
+        dataframe = pd.read_table(
             self.inputs.confounds_file,
-            sep="\t",
             index_col=None,
             dtype="float32",
             na_filter=True,

--- a/aslprep/interfaces/reports.py
+++ b/aslprep/interfaces/reports.py
@@ -242,37 +242,37 @@ class CBFSummary(SummaryInterface):
 
     def _generate_segment(self):
         qcfile = pd.read_csv(self.inputs.qc_file)
-        motionparam = f"FD : {round(qcfile['FD'][0], 4)}, rmsd: {round(qcfile['rmsd'][0], 4)} "
+        motionparam = (
+            f"FD : {round(qcfile['mean_fd'][0], 4)}, rmsd: {round(qcfile['rmsd'][0], 4)} "
+        )
         coregindex = (
-            f" Dice Index: {round(qcfile['coregDC'][0], 4)}, "
-            f"Jaccard Index: {round(qcfile['coregJC'][0], 4)}, "
-            f"Cross Cor.: {round(qcfile['coregCC'][0], 4)}, "
-            f"Coverage: {round(qcfile['coregCOV'][0], 4)} "
+            f" Dice Index: {round(qcfile['coreg_dice'][0], 4)}, "
+            f"Correlation: {round(qcfile['coreg_correlation'][0], 4)}, "
+            f"Coverage: {round(qcfile['coreg_overlap'][0], 4)} "
         )
         normindex = (
-            f" Dice Index: {round(qcfile['normDC'][0], 4)}, "
-            f"Jaccard Index: {round(qcfile['normJC'][0], 4)}, "
-            f"Cross Cor.: {round(qcfile['normCC'][0], 4)}, "
-            f"Coverage: {round(qcfile['normCOV'][0], 4)} "
+            f" Dice Index: {round(qcfile['norm_dice'][0], 4)}, "
+            f"Correlation: {round(qcfile['norm_correlation'][0], 4)}, "
+            f"Coverage: {round(qcfile['norm_overlap'][0], 4)} "
         )
         qei = (
-            f"cbf: {round(qcfile['cbfQEI'][0], 4)}, "
-            f"score: {round(qcfile['scoreQEI'][0], 4)}, "
-            f"scrub: {round(qcfile['scrubQEI'][0], 4)}, "
-            f"basil: {round(qcfile['basilQEI'][0], 4)}, "
-            f"pvc: {round(qcfile['pvcQEI'][0], 4)} "
+            f"cbf: {round(qcfile['qei_cbf'][0], 4)}, "
+            f"score: {round(qcfile['qei_cbf_score'][0], 4)}, "
+            f"scrub: {round(qcfile['qei_cbf_scrub'][0], 4)}, "
+            f"basil: {round(qcfile['qei_cbf_basil'][0], 4)}, "
+            f"pvc: {round(qcfile['qei_cbf_basil_gm'][0], 4)} "
         )
         mean_cbf = (
-            f"GM CBF: {round(qcfile['GMmeanCBF'][0], 2)}, "
-            f"WM CBF: {round(qcfile['WMmeanCBF'][0], 2)}, "
-            f"GM/WM CBF ratio: {round(qcfile['Gm_Wm_CBF_ratio'][0], 2)} "
+            f"GM CBF: {round(qcfile['mean_gm_cbf'][0], 2)}, "
+            f"WM CBF: {round(qcfile['mean_wm_cbf'][0], 2)}, "
+            f"GM/WM CBF ratio: {round(qcfile['ratio_gm_wm_cbf'][0], 2)} "
         )
         negvoxel = (
-            f"cbf: {round(qcfile['NEG_CBF_PERC'][0], 2)}, "
-            f"score: {round(qcfile['NEG_SCORE_PERC'][0], 2)}, "
-            f"scrub: {round(qcfile['NEG_SCRUB_PERC'][0], 2)}, "
-            f"basil: {round(qcfile['NEG_BASIL_PERC'][0], 2)}, "
-            f"pvc: {round(qcfile['NEG_PVC_PERC'][0], 2)} "
+            f"cbf: {round(qcfile['percentage_negative_cbf'][0], 2)}, "
+            f"score: {round(qcfile['percentage_negative_cbf_score'][0], 2)}, "
+            f"scrub: {round(qcfile['percentage_negative_cbf_scrub'][0], 2)}, "
+            f"basil: {round(qcfile['percentage_negative_cbf_basil'][0], 2)}, "
+            f"pvc: {round(qcfile['percentage_negative_cbf_basil_gm'][0], 2)} "
         )
 
         if isdefined(self.inputs.confounds_file):

--- a/aslprep/interfaces/reports.py
+++ b/aslprep/interfaces/reports.py
@@ -240,7 +240,7 @@ class CBFSummary(SummaryInterface):
     input_spec = _CBFSummaryInputSpec
 
     def _generate_segment(self):
-        qcfile = pd.read_csv(self.inputs.qc_file)
+        qcfile = pd.read_table(self.inputs.qc_file)
         motionparam = (
             f"FD : {round(qcfile['mean_fd'][0], 4)}, rmsd: {round(qcfile['rmsd'][0], 4)} "
         )

--- a/aslprep/interfaces/reports.py
+++ b/aslprep/interfaces/reports.py
@@ -1,7 +1,6 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Interfaces to generate reportlets."""
-
 import os
 import re
 import time

--- a/aslprep/tests/data/expected_outputs_examples_pasl_multipld.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pasl_multipld.txt
@@ -197,7 +197,7 @@ sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-preproc_asl.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-preproc_asl.nii.gz
-sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.csv
+sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.tsv
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.txt
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.json

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_multipld.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_multipld.txt
@@ -168,7 +168,7 @@ sub-01/perf/sub-01_desc-hmc_aslref.json
 sub-01/perf/sub-01_desc-hmc_aslref.nii.gz
 sub-01/perf/sub-01_desc-preproc_asl.json
 sub-01/perf/sub-01_desc-preproc_asl.nii.gz
-sub-01/perf/sub-01_desc-qualitycontrol_cbf.csv
+sub-01/perf/sub-01_desc-qualitycontrol_cbf.tsv
 sub-01/perf/sub-01_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/perf/sub-01_from-aslref_to-T1w_mode-image_xfm.txt
 sub-01/perf/sub-01_from-orig_to-aslref_mode-image_xfm.json

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_ge.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_ge.txt
@@ -167,7 +167,7 @@ sub-01/ses-ge3d/perf/sub-01_ses-ge3d_desc-hmc_aslref.json
 sub-01/ses-ge3d/perf/sub-01_ses-ge3d_desc-hmc_aslref.nii.gz
 sub-01/ses-ge3d/perf/sub-01_ses-ge3d_desc-preproc_asl.json
 sub-01/ses-ge3d/perf/sub-01_ses-ge3d_desc-preproc_asl.nii.gz
-sub-01/ses-ge3d/perf/sub-01_ses-ge3d_desc-qualitycontrol_cbf.csv
+sub-01/ses-ge3d/perf/sub-01_ses-ge3d_desc-qualitycontrol_cbf.tsv
 sub-01/ses-ge3d/perf/sub-01_ses-ge3d_desc-timeseries_cbf.json
 sub-01/ses-ge3d/perf/sub-01_ses-ge3d_desc-timeseries_cbf.nii.gz
 sub-01/ses-ge3d/perf/sub-01_ses-ge3d_from-aslref_to-T1w_mode-image_xfm.json

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_philips.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_philips.txt
@@ -204,7 +204,7 @@ sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-hmc_aslref.json
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-hmc_aslref.nii.gz
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-preproc_asl.json
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-preproc_asl.nii.gz
-sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-qualitycontrol_cbf.csv
+sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-qualitycontrol_cbf.tsv
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-scoreTimeseries_cbf.json
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-scoreTimeseries_cbf.nii.gz
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-score_cbf.json

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_siemens.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_siemens.txt
@@ -162,7 +162,7 @@ sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_desc-coreg_aslref.json
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_desc-coreg_aslref.nii.gz
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_desc-hmc_aslref.json
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_desc-hmc_aslref.nii.gz
-sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_desc-qualitycontrol_cbf.csv
+sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_desc-qualitycontrol_cbf.tsv
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_from-aslref_to-T1w_mode-image_xfm.txt
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_from-orig_to-aslref_mode-image_xfm.json

--- a/aslprep/tests/data/expected_outputs_qtab.txt
+++ b/aslprep/tests/data/expected_outputs_qtab.txt
@@ -140,7 +140,7 @@ sub-01/ses-01/perf/sub-01_ses-01_desc-hmc_aslref.json
 sub-01/ses-01/perf/sub-01_ses-01_desc-hmc_aslref.nii.gz
 sub-01/ses-01/perf/sub-01_ses-01_desc-preproc_asl.json
 sub-01/ses-01/perf/sub-01_ses-01_desc-preproc_asl.nii.gz
-sub-01/ses-01/perf/sub-01_ses-01_desc-qualitycontrol_cbf.csv
+sub-01/ses-01/perf/sub-01_ses-01_desc-qualitycontrol_cbf.tsv
 sub-01/ses-01/perf/sub-01_ses-01_desc-scoreTimeseries_cbf.json
 sub-01/ses-01/perf/sub-01_ses-01_desc-scoreTimeseries_cbf.nii.gz
 sub-01/ses-01/perf/sub-01_ses-01_desc-score_cbf.json
@@ -258,7 +258,7 @@ sub-01/ses-02/perf/sub-01_ses-02_desc-hmc_aslref.json
 sub-01/ses-02/perf/sub-01_ses-02_desc-hmc_aslref.nii.gz
 sub-01/ses-02/perf/sub-01_ses-02_desc-preproc_asl.json
 sub-01/ses-02/perf/sub-01_ses-02_desc-preproc_asl.nii.gz
-sub-01/ses-02/perf/sub-01_ses-02_desc-qualitycontrol_cbf.csv
+sub-01/ses-02/perf/sub-01_ses-02_desc-qualitycontrol_cbf.tsv
 sub-01/ses-02/perf/sub-01_ses-02_desc-scoreTimeseries_cbf.json
 sub-01/ses-02/perf/sub-01_ses-02_desc-scoreTimeseries_cbf.nii.gz
 sub-01/ses-02/perf/sub-01_ses-02_desc-score_cbf.json

--- a/aslprep/tests/data/expected_outputs_test_001.txt
+++ b/aslprep/tests/data/expected_outputs_test_001.txt
@@ -139,7 +139,7 @@ sub-01/perf/sub-01_desc-hmc_aslref.json
 sub-01/perf/sub-01_desc-hmc_aslref.nii.gz
 sub-01/perf/sub-01_desc-preproc_asl.json
 sub-01/perf/sub-01_desc-preproc_asl.nii.gz
-sub-01/perf/sub-01_desc-qualitycontrol_cbf.csv
+sub-01/perf/sub-01_desc-qualitycontrol_cbf.tsv
 sub-01/perf/sub-01_desc-scoreTimeseries_cbf.json
 sub-01/perf/sub-01_desc-scoreTimeseries_cbf.nii.gz
 sub-01/perf/sub-01_desc-score_cbf.json

--- a/aslprep/tests/data/expected_outputs_test_002.txt
+++ b/aslprep/tests/data/expected_outputs_test_002.txt
@@ -111,7 +111,7 @@ sub-01/perf/sub-01_desc-hmc_aslref.json
 sub-01/perf/sub-01_desc-hmc_aslref.nii.gz
 sub-01/perf/sub-01_desc-preproc_asl.json
 sub-01/perf/sub-01_desc-preproc_asl.nii.gz
-sub-01/perf/sub-01_desc-qualitycontrol_cbf.csv
+sub-01/perf/sub-01_desc-qualitycontrol_cbf.tsv
 sub-01/perf/sub-01_desc-timeseries_cbf.json
 sub-01/perf/sub-01_desc-timeseries_cbf.nii.gz
 sub-01/perf/sub-01_from-aslref_to-T1w_mode-image_xfm.json

--- a/aslprep/tests/data/expected_outputs_test_003.txt
+++ b/aslprep/tests/data/expected_outputs_test_003.txt
@@ -103,7 +103,7 @@ sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-preproc_asl.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-preproc_asl.nii.gz
-sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.csv
+sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.tsv
 sub-01/ses-1/perf/sub-01_ses-1_desc-timeseries_cbf.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-timeseries_cbf.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.json

--- a/aslprep/tests/data/expected_outputs_test_003_full.txt
+++ b/aslprep/tests/data/expected_outputs_test_003_full.txt
@@ -116,7 +116,7 @@ sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-preproc_asl.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-preproc_asl.nii.gz
-sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.csv
+sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.tsv
 sub-01/ses-1/perf/sub-01_ses-1_desc-timeseries_cbf.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-timeseries_cbf.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.json

--- a/aslprep/tests/data/expected_outputs_test_003_resampling.txt
+++ b/aslprep/tests/data/expected_outputs_test_003_resampling.txt
@@ -13,7 +13,7 @@ sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.nii.gz
-sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.csv
+sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.tsv
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.txt
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.json

--- a/aslprep/utils/confounds.py
+++ b/aslprep/utils/confounds.py
@@ -145,31 +145,6 @@ def dice(input1, input2):
     return coef
 
 
-def jaccard(input1, input2):
-    """Compute Jaccard coefficient between the binary objects in two images.
-
-    Parameters
-    ----------
-    input1/input2 : :obj:`numpy.ndarray`
-        Numpy arrays to compare.
-        Can be any type but will be converted into binary:
-        False where 0, True everywhere else.
-
-    Returns
-    -------
-    coef : float
-        The Jaccard coefficient between ``input1`` and ``input2``.
-        It ranges from 0 (no overlap) to 1 (perfect overlap).
-    """
-    input1 = np.atleast_1d(input1.astype(bool))
-    input2 = np.atleast_1d(input2.astype(bool))
-
-    intersection = np.count_nonzero(input1 & input2)
-    union = np.count_nonzero(input1 | input2)
-
-    return intersection / union
-
-
 def pearson(input1, input2):
     """Calculate Pearson product moment correlation between two images.
 

--- a/aslprep/utils/confounds.py
+++ b/aslprep/utils/confounds.py
@@ -79,7 +79,7 @@ def _gather_confounds(
 
     confounds_data = pd.DataFrame()
     for file_name in all_files:  # assumes they all have headings already
-        new = pd.read_csv(file_name, sep="\t")
+        new = pd.read_table(file_name)
         for column_name in new.columns:
             new.rename(
                 columns={column_name: _camel_to_snake(_less_breakable(column_name))}, inplace=True

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -380,7 +380,7 @@ CBF Quality Control
 
    sub-<label>/[ses-<label>/]
       perf/
-         <source_entities>_desc-qualitycontrol_cbf.csv
+         <source_entities>_desc-qualitycontrol_cbf.tsv
 
 The following QC measures were estimated: framewise displacement and relative root mean square (relRMS).
 Other QC measurers include Dice and Jaccard indices, cross-correlation,


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Rename the QC metrics from camelCase to snake_case, per BIDS convention.
- Output the QC files as TSVs instead of CSVs, per BIDS convention.