### PR TITLE
Add --ignore fmap-jacobian option

### DIFF
--- a/aslprep/cli/parser.py
+++ b/aslprep/cli/parser.py
@@ -242,7 +242,7 @@ def _build_parser():
         action="store",
         nargs="+",
         default=[],
-        choices=["fieldmaps", "sbref", "t2w", "flair"],
+        choices=["fieldmaps", "sbref", "t2w", "flair", "fmap-jacobian"],
         help=(
             "ignore selected aspects of the input dataset to disable corresponding "
             "parts of the workflow (a space delimited list)"

--- a/aslprep/workflows/asl/apply.py
+++ b/aslprep/workflows/asl/apply.py
@@ -133,6 +133,7 @@ def init_asl_cifti_resample_wf(
         fieldmap_id=fieldmap_id,
         omp_nthreads=omp_nthreads,
         mem_gb=mem_gb,
+        jacobian="fmap-jacobian" not in config.workflow.ignore,
         name="asl_MNI6_wf",
     )
 

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -563,6 +563,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
         fieldmap_id=fieldmap_id,
         omp_nthreads=omp_nthreads,
         mem_gb=mem_gb,
+        jacobian="fmap-jacobian" not in config.workflow.ignore,
         name="asl_anat_wf",
     )
     asl_anat_wf.inputs.inputnode.resolution = "native"
@@ -626,6 +627,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
             fieldmap_id=fieldmap_id,
             omp_nthreads=omp_nthreads,
             mem_gb=mem_gb,
+            jacobian="fmap-jacobian" not in config.workflow.ignore,
             name="asl_std_wf",
         )
         ds_asl_std_wf = init_ds_volumes_wf(

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -817,7 +817,7 @@ def init_asl_native_wf(
 
     # Resample ASL to aslref
     aslref_asl = pe.Node(
-        ResampleSeries(),
+        ResampleSeries(jacobian="fmap-jacobian" not in config.workflow.ignore),
         name="aslref_asl",
         n_procs=omp_nthreads,
         mem_gb=mem_gb["resampled"],
@@ -862,7 +862,11 @@ def init_asl_native_wf(
         # No HMC
         identity_xfm = nw_data.load("itkIdentityTransform.txt")
         aslref_m0scan = pe.Node(
-            ResampleSeries(transforms=[identity_xfm], in_file=m0scan),
+            ResampleSeries(
+                jacobian="fmap-jacobian" not in config.workflow.ignore,
+                transforms=[identity_xfm],
+                in_file=m0scan,
+            ),
             name="aslref_m0scan",
             n_procs=omp_nthreads,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = {file = "LICENSE.md"}
 requires-python = ">=3.10"
 dependencies = [
     'importlib_resources; python_version < "3.11"',
-    "fmriprep ~= 23.2.0a2",
+    "fmriprep ~= 23.2.0",
     "indexed_gzip >= 0.8.8",
     "looseversion",
     "networkx ~= 3.2.1",  # nipype needs networkx, but 3+ isn"t compatible with nipype 1.8.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "psutil >= 5.4",
     "pybids ~= 0.16.4",
     "requests",
-    "sdcflows ~= 2.7.0",
+    "sdcflows ~= 2.8.0",
     "sentry-sdk >= 0.6.9",
     "smriprep ~= 0.13.1",
     "templateflow >= 23.0.0",


### PR DESCRIPTION
Reproduces nipreps/fmriprep#3186 and closes #380.

## Changes proposed in this pull request

- Bump fMRIPrep version to 23.2.0.
- Bump SDCFlows version to 2.8.0.
- Add `--ignore fmap-jacobian` option to disable Jacobian determinant modulation during fieldmap correction.