### PR TITLE
Fix CBF CIFTI generation when `--project-goodvoxels` is enabled

### DIFF
--- a/aslprep/tests/test_cli.py
+++ b/aslprep/tests/test_cli.py
@@ -355,7 +355,7 @@ def test_test_003_full(data_dir, output_dir, working_dir):
         output_dir,
         working_dir,
         level='full',
-        extra_params=['--cifti-output', '91k'],
+        extra_params=['--cifti-output', '91k', '--project-goodvoxels'],
     )
 
 

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -770,6 +770,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf` (FreeSurfe
         ds_asl_cifti_wf.inputs.inputnode.source_files = [asl_file]
         workflow.connect([
             (inputnode, ds_asl_cifti_wf, [
+                ('t1w_preproc', 'inputnode.anat'),
                 ('mni6_mask', 'inputnode.mni6_mask'),
                 ('anat2mni6_xfm', 'inputnode.anat2mni6_xfm'),
                 ('white', 'inputnode.white'),
@@ -778,10 +779,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf` (FreeSurfe
                 ('midthickness_fsLR', 'inputnode.midthickness_fsLR'),
                 ('sphere_reg_fsLR', 'inputnode.sphere_reg_fsLR'),
                 ('cortex_mask', 'inputnode.cortex_mask'),
-            ]),
-            (asl_anat_wf, ds_asl_cifti_wf, [
-                # Used for affine/resolution reference only
-                ('outputnode.resampling_reference', 'inputnode.anat_ref_file'),
             ]),
             (asl_fit_wf, ds_asl_cifti_wf, [
                 ('outputnode.aslref2anat_xfm', 'inputnode.aslref2anat_xfm'),

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -770,7 +770,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf` (FreeSurfe
         ds_asl_cifti_wf.inputs.inputnode.source_files = [asl_file]
         workflow.connect([
             (inputnode, ds_asl_cifti_wf, [
-                ('t1w_preproc', 'inputnode.anat'),
                 ('mni6_mask', 'inputnode.mni6_mask'),
                 ('anat2mni6_xfm', 'inputnode.anat2mni6_xfm'),
                 ('white', 'inputnode.white'),
@@ -779,6 +778,10 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf` (FreeSurfe
                 ('midthickness_fsLR', 'inputnode.midthickness_fsLR'),
                 ('sphere_reg_fsLR', 'inputnode.sphere_reg_fsLR'),
                 ('cortex_mask', 'inputnode.cortex_mask'),
+            ]),
+            (asl_anat_wf, ds_asl_cifti_wf, [
+                # Used for affine/resolution reference only
+                ('outputnode.resampling_reference', 'inputnode.anat_ref_file'),
             ]),
             (asl_fit_wf, ds_asl_cifti_wf, [
                 ('outputnode.aslref2anat_xfm', 'inputnode.aslref2anat_xfm'),

--- a/aslprep/workflows/asl/outputs.py
+++ b/aslprep/workflows/asl/outputs.py
@@ -837,11 +837,12 @@ def init_ds_ciftis_wf(
     inputnode_fields = [
         'asl_cifti',
         'source_files',
-        # Anatomical
+        # ASL-resolution, anatomical-space reference image
         'anat_ref_file',
         'aslref2anat_xfm',
         # Template
         'anat2mni6_xfm',
+        # Template reference image. Resolution depends on CIFTI output resolution
         'mni6_mask',
         # Pre-computed goodvoxels mask. May be Undefined.
         'goodvoxels_mask',

--- a/aslprep/workflows/asl/outputs.py
+++ b/aslprep/workflows/asl/outputs.py
@@ -838,7 +838,7 @@ def init_ds_ciftis_wf(
         'asl_cifti',
         'source_files',
         # Anatomical
-        'anat_ref_file',
+        'anat',
         'aslref2anat_xfm',
         # Template
         'anat2mni6_xfm',
@@ -927,7 +927,7 @@ def init_ds_ciftis_wf(
         workflow.connect([
             (inputnode, warp_cbf_to_anat, [
                 (cbf_deriv, 'input_image'),
-                ('anat_ref_file', 'reference_image'),
+                ('anat', 'reference_image'),
                 ('aslref2anat_xfm', 'transforms'),
             ]),
         ])  # fmt:skip

--- a/aslprep/workflows/asl/outputs.py
+++ b/aslprep/workflows/asl/outputs.py
@@ -838,7 +838,7 @@ def init_ds_ciftis_wf(
         'asl_cifti',
         'source_files',
         # Anatomical
-        'anat',
+        'anat_ref_file',
         'aslref2anat_xfm',
         # Template
         'anat2mni6_xfm',
@@ -927,7 +927,7 @@ def init_ds_ciftis_wf(
         workflow.connect([
             (inputnode, warp_cbf_to_anat, [
                 (cbf_deriv, 'input_image'),
-                ('anat', 'reference_image'),
+                ('anat_ref_file', 'reference_image'),
                 ('aslref2anat_xfm', 'transforms'),
             ]),
         ])  # fmt:skip


### PR DESCRIPTION
Closes #459.

## Changes proposed in this pull request

- Replace high-resolution anatomical image in `ds_ciftis_wf` with ASL-resolution reference image from `asl_anat_wf`.
- Update variable names and documentation to be clearer. 