### PR TITLE
Ignore remaining ruff issues

### DIFF
--- a/aslprep/config.py
+++ b/aslprep/config.py
@@ -149,7 +149,7 @@ if not _disable_et:
     # Just get so analytics track one hit
     from contextlib import suppress
 
-    from requests import ConnectionError, ReadTimeout
+    from requests import ConnectionError, ReadTimeout  # noqa: A004
     from requests import get as _get_url
 
     with suppress((ConnectionError, ReadTimeout)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ extend-select = [
   "Q",
 ]
 ignore = [
+  "UP031",  # TODO: Fix these
   "S311",  # We are not using random for cryptographic purposes
   "ISC001",
   "S603",


### PR DESCRIPTION
Ruff was passing until this past week, at which point it suddenly started identifying %-formatting that it wasn't before. The new errors look to be true positives, but I don't have the time to address them all right now, so I'm going to ignore them.
