### PR TITLE
Upgrade to deno-based BIDS validator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 
 .dockersetup: &dockersetup
   docker:
-    - image: pennlinc/aslprep_build:main
+    - image: pennlinc/aslprep_build:0.0.12
   working_directory: /src/aslprep
 
 runinstall: &runinstall

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 
 .dockersetup: &dockersetup
   docker:
-    - image: pennlinc/aslprep_build:0.0.11
+    - image: pennlinc/aslprep_build:main
   working_directory: /src/aslprep
 
 runinstall: &runinstall

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pennlinc/aslprep_build:0.0.11
+FROM pennlinc/aslprep_build:0.0.12
 
 # Install aslprep
 COPY . /src/aslprep


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Bump validator version to new schema-based, deno release.