### PR TITLE
Fix volume selection and temporarily remove `--dummy-scans` parameter

### DIFF
--- a/aslprep/cli/parser.py
+++ b/aslprep/cli/parser.py
@@ -351,18 +351,18 @@ any spatial references.""",
         default=None,
         help='Do not use boundary-based registration (no goodness-of-fit checks)',
     )
-    g_conf.add_argument(
-        '--dummy-scans',
-        required=False,
-        action='store',
-        default=None,
-        type=int,
-        help=(
-            'Number of non-steady-state volumes. '
-            'Note that this indicates the number of volumes, not the number of control-label '
-            'pairs in the ASL file.'
-        ),
-    )
+    # g_conf.add_argument(
+    #     '--dummy-scans',
+    #     required=False,
+    #     action='store',
+    #     default=None,
+    #     type=int,
+    #     help=(
+    #         'Number of non-steady-state volumes. '
+    #         'Note that this indicates the number of volumes, not the number of control-label '
+    #         'pairs in the ASL file.'
+    #     ),
+    # )
     g_conf.add_argument(
         '--random-seed',
         dest='_random_seed',

--- a/aslprep/config.py
+++ b/aslprep/config.py
@@ -544,7 +544,8 @@ class workflow(_Config):
     cifti_output = None
     """Generate HCP Grayordinates, accepts either ``'91k'`` (default) or ``'170k'``."""
     dummy_scans = 0
-    """Number of label-control volume pairs to delete before CBF computation."""
+    """Number of label-control volume pairs to delete before CBF computation. Not currently used.
+    """
     fmap_bspline = None
     """Regularize fieldmaps with a field of B-Spline basis."""
     fmap_demean = None

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -400,6 +400,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
         (asl_native_wf, cbf_wf, [
             ('outputnode.asl_native', 'inputnode.asl_file'),
             ('outputnode.aslcontext', 'inputnode.aslcontext'),
+            ('outputnode.metadata', 'inputnode.metadata'),
             ('outputnode.m0scan_native', 'inputnode.m0scan'),
         ]),
     ])  # fmt:skip

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -76,7 +76,9 @@ def init_cbf_wf(
     name_source : :obj:`str`
         Path to the raw ASL file.
     metadata : :obj:`dict`
-        BIDS metadata for asl file
+        BIDS metadata for asl file.
+        List-type fields in this dict have not been reduced based on selected volumes,
+        so this should only be used for metadata that is not affected by volume selection.
     scorescrub
     basil
     m0_scale
@@ -89,6 +91,10 @@ def init_cbf_wf(
     asl_file
         asl series NIfTI file, after preprocessing
     aslcontext : :obj:`str`
+    metadata : :obj:`dict`
+        Metadata dictionary associated with asl_file, after preprocessing.
+        List-type fields in this dict *have* been reduced based on selected volumes,
+        so this is the dictionary that should be used to select volumes.
     m0scan : :obj:`str` or None
         An M0 scan (if available as a separate file) in aslref space.
     m0scan_metadata : :obj:`dict` or None
@@ -371,7 +377,6 @@ using the Q2TIPS modification, as described in @noguchi2015technical.
             name_source=name_source,
             dummy_scans=dummy_scans,
             fwhm=smooth_kernel,
-            metadata=metadata,
         ),
         mem_gb=0.2,
         run_without_submitting=True,
@@ -381,6 +386,7 @@ using the Q2TIPS modification, as described in @noguchi2015technical.
     workflow.connect([
         (inputnode, extract_deltam, [
             ('asl_file', 'asl_file'),
+            ('metadata', 'metadata'),
             ('aslcontext', 'aslcontext'),
             ('m0scan_metadata', 'm0scan_metadata'),
         ]),

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -230,6 +230,7 @@ using the Q2TIPS modification, as described in @noguchi2015technical.
             fields=[
                 'asl_file',
                 'aslcontext',
+                'metadata',
                 'm0scan',
                 'm0scan_metadata',
                 'asl_mask',


### PR DESCRIPTION
Closes none, but addresses a bug identified by user cindylucerog in https://neurostars.org/t/extract-deltam-failed-to-run/31056.

## Changes proposed in this pull request

- Use reduced version of metadata in ExtractCBF calls. This is the version of metadata produced by `asl_native_wf`, wherein volume-wise fields only retain values from relevant volumes.
- Disable the `--dummy-scans` parameter temporarily, because it wasn't working as intended. **THIS IS A BREAKING CHANGE.**