### PR TITLE
Return the mean M0 TR in ExtractCBF

### DIFF
--- a/aslprep/interfaces/cbf.py
+++ b/aslprep/interfaces/cbf.py
@@ -285,7 +285,7 @@ class ExtractCBF(SimpleInterface):
                 metadata[field] = value
 
         self._results['metadata'] = metadata
-        self._results['m0tr'] = m0tr
+        self._results['m0tr'] = np.mean(m0tr) if m0tr is not None else None
         self._results['out_file'] = fname_presuffix(
             self.inputs.name_source,
             suffix='_DeltaMOrCBF',


### PR DESCRIPTION
Closes none, but addresses a bug identified by user cindylucerog in https://neurostars.org/t/extract-deltam-failed-to-run/31056.

## Changes proposed in this pull request

- In cases where there are multiple included M0 volumes, return the mean M0 TR in ExtractCBF instead of the full array.