### PR TITLE
Output fsLR meshes on subject surfaces

### DIFF
--- a/aslprep/tests/data/expected_outputs_test_003_full.txt
+++ b/aslprep/tests/data/expected_outputs_test_003_full.txt
@@ -81,8 +81,14 @@ sub-01/anat
 sub-01/anat/sub-01_desc-ribbon_mask.json
 sub-01/anat/sub-01_desc-ribbon_mask.nii.gz
 sub-01/anat/sub-01_hemi-L_desc-preproc_sphere.surf.gii
+sub-01/anat/sub-01_hemi-L_space-fsLR_den-32k_desc-preproc_midthickness.surf.gii
+sub-01/anat/sub-01_hemi-L_space-fsLR_den-32k_desc-preproc_pial.surf.gii
+sub-01/anat/sub-01_hemi-L_space-fsLR_den-32k_desc-preproc_white.surf.gii
 sub-01/anat/sub-01_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
 sub-01/anat/sub-01_hemi-R_desc-preproc_sphere.surf.gii
+sub-01/anat/sub-01_hemi-R_space-fsLR_den-32k_desc-preproc_midthickness.surf.gii
+sub-01/anat/sub-01_hemi-R_space-fsLR_den-32k_desc-preproc_pial.surf.gii
+sub-01/anat/sub-01_hemi-R_space-fsLR_den-32k_desc-preproc_white.surf.gii
 sub-01/anat/sub-01_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii
 sub-01/anat/sub-01_space-fsLR_den-91k_desc-preproc_curv.dscalar.nii
 sub-01/anat/sub-01_space-fsLR_den-91k_desc-preproc_curv.json

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -133,6 +133,9 @@ If FreeSurfer reconstructions are used, the following surface files are generate
       sub-<label>_hemi-[LR]_desc-reg_sphere.surf.gii
       sub-<label>_hemi-[LR]_space-fsLR_desc-reg_sphere.surf.gii
       sub-<label>_hemi-[LR]_space-fsLR_desc-msmsulc_sphere.surf.gii
+      sub-<label>_hemi-[LR]_space-fsLR_den-32k_desc-preproc_white.surf.gii
+      sub-<label>_hemi-[LR]_space-fsLR_den-32k_desc-preproc_midthickness.surf.gii
+      sub-<label>_hemi-[LR]_space-fsLR_den-32k_desc-preproc_pial.surf.gii
 
 The registration spheres target ``fsaverage`` and ``fsLR`` spaces. If MSM
 is enabled (i.e., the ``--no-msm`` flag is not passed), then the ``msmsulc``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "requests",
     "sdcflows <= 2.11.0",
     "sentry-sdk <= 2.19.2",
-    "smriprep <= 0.16.1",
+    "smriprep <= 0.17.0",
     "templateflow <= 24.2.2",
     "toml",
 ]


### PR DESCRIPTION
Closes none. Implementation of nipreps/fmriprep#3411.

## Changes proposed in this pull request

- Increase maximum sMRIPrep version from 0.16.1 to 0.17.0.
- Replace sMRIPrep's `init_resample_midthickness_wf` with `init_resample_surfaces_wf` and write out subject-space meshes.