### PR TITLE
fix: Find aslrefs in precomputed derivatives, remove bad connection

### DIFF
--- a/aslprep/cli/run.py
+++ b/aslprep/cli/run.py
@@ -41,7 +41,7 @@ def main():
     parse_args()
 
     if 'pdb' in config.execution.debug:
-        from aslprep.utils.debug import setup_exceptionhook
+        from fmriprep.utils.debug import setup_exceptionhook
 
         setup_exceptionhook()
         config.nipype.plugin = 'Linear'

--- a/aslprep/data/fmap_spec.json
+++ b/aslprep/data/fmap_spec.json
@@ -1,0 +1,33 @@
+{
+  "queries": {
+    "fieldmaps": {
+      "fieldmap": {
+        "datatype": "fmap",
+        "desc": "preproc",
+        "suffix": "fieldmap",
+        "extension": [
+          ".nii.gz",
+          ".nii"
+        ]
+      },
+      "coeffs": {
+        "datatype": "fmap",
+        "desc": ["coeff", "coeff0", "coeff1"],
+        "suffix": "fieldmap",
+        "extension": [
+          ".nii.gz",
+          ".nii"
+        ]
+      },
+      "magnitude": {
+        "datatype": "fmap",
+        "desc": ["magnitude", "epi"],
+        "suffix": "fieldmap",
+        "extension": [
+          ".nii.gz",
+          ".nii"
+        ]
+      }
+    }
+  }
+}

--- a/aslprep/data/io_spec.json
+++ b/aslprep/data/io_spec.json
@@ -2,7 +2,7 @@
   "queries": {
     "baseline": {
       "hmc": {
-        "datatype": "func",
+        "datatype": "perf",
         "space": null,
         "desc": "hmc",
         "suffix": "aslref",
@@ -12,7 +12,7 @@
         ]
       },
       "coreg": {
-        "datatype": "func",
+        "datatype": "perf",
         "space": null,
         "desc": "coreg",
         "suffix": "aslref",
@@ -49,9 +49,9 @@
     }
   },
   "patterns": [
-    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_res-{res}][_label-{label}][_echo-{echo}][_space-{space}][_desc-{desc}]_{suffix<asl|aslref|dseg|mask>}.{extension<nii|nii.gz|json>|nii.gz}",
-    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}]_from-{from}_to-{to}_mode-{mode<image|points>|image}_{suffix<xfm>|xfm}.{extension<txt|h5>}",
-    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}][_part-{part}][_desc-{desc}]_{suffix<timeseries>}.{extension<tsv|json>}",
-    "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_space-{space}][_res-{res}][_den-{den}][_hemi-{hemi}[_label-{label}][_desc-{desc}]_{suffix<|aslref|dseg|mask>}.{extension<dtseries.nii|dtseries.json>}"
+    "sub-{subject}[/ses-{session}]/{datatype<perf>|perf}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_res-{res}][_label-{label}][_echo-{echo}][_space-{space}][_desc-{desc}]_{suffix<asl|aslref|dseg|mask>}.{extension<nii|nii.gz|json>|nii.gz}",
+    "sub-{subject}[/ses-{session}]/{datatype<perf>|perf}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}]_from-{from}_to-{to}_mode-{mode<image|points>|image}_{suffix<xfm>|xfm}.{extension<txt|h5>}",
+    "sub-{subject}[/ses-{session}]/{datatype<perf>|perf}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_run-{run}][_part-{part}][_desc-{desc}]_{suffix<timeseries>}.{extension<tsv|json>}",
+    "sub-{subject}[/ses-{session}]/{datatype<perf>|perf}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_space-{space}][_res-{res}][_den-{den}][_hemi-{hemi}[_label-{label}][_desc-{desc}]_{suffix<|aslref|dseg|mask>}.{extension<dtseries.nii|dtseries.json>}"
   ]
 }

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -424,7 +424,6 @@ def init_asl_fit_wf(
         workflow.connect([
             (validation_and_dummies_wf, hmcref_buffer, [
                 ('outputnode.bold_file', 'asl_file'),
-                ('outputnode.skip_vols', 'dummy_scans'),
             ]),
             (validation_and_dummies_wf, asl_fit_reports_wf, [
                 ('outputnode.validation_report', 'inputnode.validation_report'),

--- a/aslprep/workflows/base.py
+++ b/aslprep/workflows/base.py
@@ -512,12 +512,19 @@ their manuscripts unchanged. It is released under the unchanged
 
     fmap_cache = {}
     if config.execution.derivatives:
+        import json
+
         from fmriprep.utils.bids import collect_fieldmaps
+
+        from ..data import load as load_data
+
+        spec = json.loads(load_data.readable('fmap_spec.json').read_text())['queries']
 
         for deriv_dir in config.execution.derivatives.values():
             fmaps = collect_fieldmaps(
                 derivatives_dir=deriv_dir,
                 entities={'subject': subject_id},
+                spec=spec,
             )
             config.loggers.workflow.debug(
                 'Detected precomputed fieldmaps in %s for fieldmap IDs: %s', deriv_dir, list(fmaps)


### PR DESCRIPTION
## Changes proposed in this pull request

These changes are aimed at getting aslprep to accept precomputed derivatives using the following commands:

```console
$ aslprep sourcedata/raw aslprep-minimal participant --level=minimal [OPTIONS]
$ aslprep sourcedata/raw aslprep-full participant --derivatives aslprep=$PWD/aslprep-minimal/ [OPTIONS]
```

`aslref`s weren't being found due to the datatype being declared as `func`. Once found, the fallback workflow to generating the hmcref attempted to push a `dummy_scans` value to `hmcref_buffer`, which duplicated an input from `inputnode`. Since this only was being passed through a series of `IdentityInterface`s and never used, I just stripped that field out of the fit workflow altogether.