### PR TITLE
Write out aslref CBF + ATT in minimal mode

### DIFF
--- a/aslprep/cli/parser.py
+++ b/aslprep/cli/parser.py
@@ -275,6 +275,7 @@ def _build_parser():
             "Processing level; may be 'minimal' (nothing that can be recomputed), "
             "'resampling' (recomputable targets that aid in resampling) "
             "or 'full' (all target outputs). "
+            "Currently, 'minimal' and 'resampling' are effectively the same."
         ),
     )
     g_subset.add_argument(

--- a/aslprep/config.py
+++ b/aslprep/config.py
@@ -558,7 +558,9 @@ class workflow(_Config):
     force = None
     """Force particular steps for *ASLPrep*."""
     level = 'full'
-    """Level of preprocessing to complete. One of ['minimal', 'resampling', 'full']."""
+    """Level of preprocessing to complete. One of ['minimal', 'resampling', 'full'].
+    'minimal' and 'resampling' are effectively the same at the moment.
+    """
     longitudinal = False
     """Run FreeSurfer ``recon-all`` with the ``--longitudinal`` flag."""
     run_msmsulc = True

--- a/aslprep/tests/data/expected_outputs_test_003_minimal.txt
+++ b/aslprep/tests/data/expected_outputs_test_003_minimal.txt
@@ -7,12 +7,16 @@ sub-01
 sub-01.html
 sub-01/ses-1
 sub-01/ses-1/perf
+sub-01/ses-1/perf/sub-01_ses-1_cbf.json
+sub-01/ses-1/perf/sub-01_ses-1_cbf.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-brain_mask.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-brain_mask.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.nii.gz
+sub-01/ses-1/perf/sub-01_ses-1_desc-timeseries_cbf.json
+sub-01/ses-1/perf/sub-01_ses-1_desc-timeseries_cbf.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.txt
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.json

--- a/aslprep/tests/data/expected_outputs_test_003_minimal.txt
+++ b/aslprep/tests/data/expected_outputs_test_003_minimal.txt
@@ -12,15 +12,15 @@ sub-01/ses-1/perf/sub-01_ses-1_cbf.json
 sub-01/ses-1/perf/sub-01_ses-1_cbf.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-brain_mask.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-brain_mask.nii.gz
+sub-01/ses-1/perf/sub-01_ses-1_desc-confounds_timeseries.tsv
 sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.nii.gz
+sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.tsv
 sub-01/ses-1/perf/sub-01_ses-1_desc-timeseries_cbf.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-timeseries_cbf.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.txt
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.txt
-sub-01/ses-1/perf/sub-01_ses-1_desc-confounds_timeseries.tsv
-sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.tsv

--- a/aslprep/tests/data/expected_outputs_test_003_minimal.txt
+++ b/aslprep/tests/data/expected_outputs_test_003_minimal.txt
@@ -1,3 +1,4 @@
+desc-qualitycontrol_cbf.json
 logs
 logs/CITATION.bib
 logs/CITATION.html
@@ -21,3 +22,5 @@ sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.txt
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.txt
+sub-01/ses-1/perf/sub-01_ses-1_desc-confounds_timeseries.tsv
+sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.tsv

--- a/aslprep/tests/data/expected_outputs_test_003_resampling.txt
+++ b/aslprep/tests/data/expected_outputs_test_003_resampling.txt
@@ -13,6 +13,7 @@ sub-01/ses-1/perf/sub-01_ses-1_cbf.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-brain_mask.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-brain_mask.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-confounds_timeseries.tsv
+sub-01/ses-1/perf/sub-01_ses-1_desc-confounds_timeseries.tsv
 sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.json
@@ -24,5 +25,3 @@ sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.txt
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.txt
-sub-01/ses-1/perf/sub-01_ses-1_desc-confounds_timeseries.tsv
-sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.tsv

--- a/aslprep/tests/data/expected_outputs_test_003_resampling.txt
+++ b/aslprep/tests/data/expected_outputs_test_003_resampling.txt
@@ -8,6 +8,8 @@ sub-01
 sub-01.html
 sub-01/ses-1
 sub-01/ses-1/perf
+sub-01/ses-1/perf/sub-01_ses-1_cbf.json
+sub-01/ses-1/perf/sub-01_ses-1_cbf.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-brain_mask.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-brain_mask.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-confounds_timeseries.tsv
@@ -16,6 +18,8 @@ sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.tsv
+sub-01/ses-1/perf/sub-01_ses-1_desc-timeseries_cbf.json
+sub-01/ses-1/perf/sub-01_ses-1_desc-timeseries_cbf.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.txt
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.json

--- a/aslprep/tests/data/expected_outputs_test_003_resampling.txt
+++ b/aslprep/tests/data/expected_outputs_test_003_resampling.txt
@@ -24,3 +24,5 @@ sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-aslref_to-T1w_mode-image_xfm.txt
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.json
 sub-01/ses-1/perf/sub-01_ses-1_from-orig_to-aslref_mode-image_xfm.txt
+sub-01/ses-1/perf/sub-01_ses-1_desc-confounds_timeseries.tsv
+sub-01/ses-1/perf/sub-01_ses-1_desc-qualitycontrol_cbf.tsv

--- a/aslprep/tests/data/expected_outputs_test_003_resampling.txt
+++ b/aslprep/tests/data/expected_outputs_test_003_resampling.txt
@@ -13,7 +13,6 @@ sub-01/ses-1/perf/sub-01_ses-1_cbf.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-brain_mask.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-brain_mask.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-confounds_timeseries.tsv
-sub-01/ses-1/perf/sub-01_ses-1_desc-confounds_timeseries.tsv
 sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.json
 sub-01/ses-1/perf/sub-01_ses-1_desc-coreg_aslref.nii.gz
 sub-01/ses-1/perf/sub-01_ses-1_desc-hmc_aslref.json

--- a/aslprep/tests/utils.py
+++ b/aslprep/tests/utils.py
@@ -93,7 +93,7 @@ def check_generated_files(aslprep_dir, output_list_file):
         expected_files = fobj.readlines()
         expected_files = [f.rstrip() for f in expected_files]
 
-    if sorted(found_files) != sorted(expected_files):
+    if sorted(set(found_files)) != sorted(set(expected_files)):
         expected_not_found = sorted(set(expected_files) - set(found_files))
         found_not_expected = sorted(set(found_files) - set(expected_files))
 

--- a/aslprep/tests/utils.py
+++ b/aslprep/tests/utils.py
@@ -204,7 +204,7 @@ def reorder_expected_outputs():
         with open(expected_output_file) as fobj:
             file_contents = fobj.readlines()
 
-        file_contents = sorted(file_contents)
+        file_contents = sorted(set(file_contents))
 
         with open(expected_output_file, 'w') as fobj:
             fobj.writelines(file_contents)

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -414,7 +414,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
     aslref_out = bool(nonstd_spaces.intersection(('func', 'run', 'asl', 'aslref', 'sbref')))
     aslref_out &= config.workflow.level == 'full'
 
-    if (config.workflow.level == 'minimal') or aslref_out:
+    if (config.workflow.level in ['minimal', 'resampling']) or aslref_out:
         ds_asl_native_wf = init_ds_asl_native_wf(
             bids_root=str(config.execution.bids_dir),
             output_dir=config.execution.aslprep_dir,
@@ -427,7 +427,6 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
         ds_asl_native_wf.inputs.inputnode.source_files = [asl_file]
 
         workflow.connect([
-            (asl_fit_wf, ds_asl_native_wf, [('outputnode.asl_mask', 'inputnode.asl_mask')]),
             (asl_native_wf, ds_asl_native_wf, [('outputnode.asl_native', 'inputnode.asl')]),
         ])  # fmt:skip
 

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -429,8 +429,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
         workflow.connect([
             (asl_native_wf, ds_asl_native_wf, [('outputnode.asl_native', 'inputnode.asl')]),
             (cbf_wf, ds_asl_native_wf, [
-                (f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}')
-                for cbf_deriv in cbf_derivs
+                (f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}') for cbf_deriv in cbf_derivs
             ]),
         ])  # fmt:skip
 
@@ -530,6 +529,9 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
         (cbf_wf, cbf_reporting_wf, [
             ('outputnode.score_outlier_index', 'inputnode.score_outlier_index'),
         ]),
+        (cbf_wf, cbf_reporting_wf, [
+            (f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}') for cbf_deriv in cbf_derivs
+        ]),
         (cbf_confounds_wf, cbf_reporting_wf, [('outputnode.qc_file', 'inputnode.qc_file')]),
         (asl_fit_wf, cbf_reporting_wf, [
             ('outputnode.coreg_aslref', 'inputnode.aslref'),
@@ -542,11 +544,6 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
             ('outputnode.acompcor_masks', 'inputnode.acompcor_masks'),
         ]),
     ])  # fmt:skip
-
-    for cbf_deriv in cbf_derivs:
-        workflow.connect([
-            (cbf_wf, cbf_reporting_wf, [(f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}')]),
-        ])  # fmt:skip
 
     if config.workflow.level == 'resampling':
         # Fill in datasinks of reportlets seen so far
@@ -610,12 +607,10 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
                 ('outputnode.aslref2anat_xfm', 'inputnode.aslref2anat_xfm'),
             ]),
             (asl_anat_wf, ds_asl_t1_wf, [('outputnode.bold_file', 'inputnode.asl')]),
+            (cbf_wf, ds_asl_t1_wf, [
+                (f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}') for cbf_deriv in cbf_derivs
+            ]),
         ])  # fmt:skip
-
-        for cbf_deriv in cbf_derivs:
-            workflow.connect([
-                (cbf_wf, ds_asl_t1_wf, [(f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}')]),
-            ])  # fmt:skip
 
     # Resample derivatives to standard space and write them out.
     # This is different from having internally-produced standard-space data.
@@ -676,12 +671,10 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
                 ('outputnode.bold_file', 'inputnode.asl'),
                 ('outputnode.resampling_reference', 'inputnode.ref_file'),
             ]),
+            (cbf_wf, ds_asl_std_wf, [
+                (f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}') for cbf_deriv in cbf_derivs
+            ]),
         ])  # fmt:skip
-
-        for cbf_deriv in cbf_derivs:
-            workflow.connect([
-                (cbf_wf, ds_asl_std_wf, [(f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}')]),
-            ])  # fmt:skip
 
     # GIFTI outputs
     if config.workflow.run_reconall and freesurfer_spaces:
@@ -717,11 +710,10 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf` (FreeSurfe
             (asl_fit_wf, asl_surf_wf, [
                 ('outputnode.aslref2anat_xfm', 'inputnode.aslref2anat_xfm'),
             ]),
+            (cbf_wf, asl_surf_wf, [
+                (f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}') for cbf_deriv in cbf_derivs
+            ]),
         ])  # fmt:skip
-        for cbf_deriv in cbf_derivs:
-            workflow.connect([
-                (cbf_wf, asl_surf_wf, [(f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}')]),
-            ])  # fmt:skip
 
     if config.workflow.cifti_output:
         asl_cifti_resample_wf = init_asl_cifti_resample_wf(
@@ -788,15 +780,14 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf` (FreeSurfe
             (asl_fit_wf, ds_asl_cifti_wf, [
                 ('outputnode.aslref2anat_xfm', 'inputnode.aslref2anat_xfm'),
             ]),
+            (cbf_wf, ds_asl_cifti_wf, [
+                (f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}') for cbf_deriv in cbf_derivs
+            ]),
             (asl_cifti_resample_wf, ds_asl_cifti_wf, [
                 ('outputnode.asl_cifti', 'inputnode.asl_cifti'),
                 ('outputnode.goodvoxels_mask', 'inputnode.goodvoxels_mask'),
             ]),
         ])  # fmt:skip
-        for cbf_deriv in cbf_derivs:
-            workflow.connect([
-                (cbf_wf, ds_asl_cifti_wf, [(f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}')]),
-            ])  # fmt:skip
 
         # Feed CIFTI into CBF-reporting workflow
         if 'cbf_ts' in cbf_4d_derivs:

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -414,7 +414,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
     aslref_out = bool(nonstd_spaces.intersection(('func', 'run', 'asl', 'aslref', 'sbref')))
     aslref_out &= config.workflow.level == 'full'
 
-    if (config.workflow.level in ['minimal', 'resampling']) or aslref_out:
+    if (config.workflow.level in ('minimal', 'resampling')) or aslref_out:
         ds_asl_native_wf = init_ds_asl_native_wf(
             bids_root=str(config.execution.bids_dir),
             output_dir=config.execution.aslprep_dir,
@@ -432,17 +432,6 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
                 (f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}') for cbf_deriv in cbf_derivs
             ]),
         ])  # fmt:skip
-
-    if config.workflow.level == 'minimal':
-        return workflow
-
-    #
-    # Resampling outputs workflow:
-    #   - Calculate ASL confounds and CBF QC metrics.
-    #   - Generate plots for CBF.
-    #   - Resample to anatomical space.
-    #   - Save aslref-space outputs only if requested.
-    #
 
     asl_confounds_wf = init_asl_confounds_wf(
         n_volumes=n_vols,
@@ -513,7 +502,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
     # NOTE: CIFTI input won't be provided unless level is set to 'full'.
     cbf_reporting_wf = init_cbf_reporting_wf(
         metadata=metadata,
-        plot_timeseries=not (is_multi_pld or use_ge or (config.workflow.level == 'resampling')),
+        plot_timeseries=not (is_multi_pld or use_ge or (config.workflow.level in ('minimal', 'resampling'))),
         scorescrub=scorescrub,
         basil=basil,
         name='cbf_reporting_wf',
@@ -545,7 +534,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
         ]),
     ])  # fmt:skip
 
-    if config.workflow.level == 'resampling':
+    if config.workflow.level in ('minimal', 'resampling'):
         # Fill in datasinks of reportlets seen so far
         for node in workflow.list_node_names():
             if node.split('.')[-1].startswith('ds_report'):

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -410,7 +410,10 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
         ]),
     ])  # fmt:skip
 
-    # If we want aslref-space outputs, then call the appropriate workflow
+    # In minimal or resampling mode, aslref-space CBF derivatives are always written out.
+    # In full mode, they are only written out if aslref is a requested output space.
+    # Additionally, the preprocessed ASL data is only written out if it is a requested output
+    # space and full mode is enabled.
     aslref_out = bool(nonstd_spaces.intersection(('func', 'run', 'asl', 'aslref', 'sbref')))
     aslref_out &= config.workflow.level == 'full'
 

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -502,7 +502,9 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
     # NOTE: CIFTI input won't be provided unless level is set to 'full'.
     cbf_reporting_wf = init_cbf_reporting_wf(
         metadata=metadata,
-        plot_timeseries=not (is_multi_pld or use_ge or (config.workflow.level in ('minimal', 'resampling'))),
+        plot_timeseries=not (
+            is_multi_pld or use_ge or (config.workflow.level in ('minimal', 'resampling'))
+        ),
         scorescrub=scorescrub,
         basil=basil,
         name='cbf_reporting_wf',

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -428,14 +428,11 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
 
         workflow.connect([
             (asl_native_wf, ds_asl_native_wf, [('outputnode.asl_native', 'inputnode.asl')]),
+            (cbf_wf, ds_asl_native_wf, [
+                (f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}')
+                for cbf_deriv in cbf_derivs
+            ]),
         ])  # fmt:skip
-
-        for cbf_deriv in cbf_derivs:
-            workflow.connect([
-                (cbf_wf, ds_asl_native_wf, [
-                    (f'outputnode.{cbf_deriv}', f'inputnode.{cbf_deriv}'),
-                ]),
-            ])  # fmt:skip
 
     if config.workflow.level == 'minimal':
         return workflow

--- a/aslprep/workflows/asl/outputs.py
+++ b/aslprep/workflows/asl/outputs.py
@@ -510,7 +510,6 @@ def init_ds_asl_native_wf(
     inputnode_fields = [
         'source_files',
         'asl',
-        'asl_mask',
     ]
     inputnode_fields += cbf_3d
     inputnode_fields += cbf_4d
@@ -572,6 +571,7 @@ def init_ds_asl_native_wf(
         workflow.connect([(inputnode, ds_att, [(att_name, 'in_file')])])
 
     if asl_output:
+        # Write out the preprocessed ASL time series
         ds_asl = pe.Node(
             DerivativesDataSink(
                 base_directory=output_dir,

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -60,12 +60,12 @@ As of version 0.6.0, ASLPrep supports three levels of derivatives:
   processing results to be deterministically generated.
   Most components of the `visual reports`_ can be generated at this level,
   so the quality of preprocessing can be assessed.
-  Because no resampling is done, confounds and carpetplots will be missing from the reports.
   ASL-reference-space CBF derivatives will automatically be generated if this level is selected.
 * ``--level resampling``: This processing mode aims to produce additional
-  derivatives that enable third-party resampling, resampling BOLD series
+  derivatives that enable third-party resampling, resampling ASL series
   in the working directory as needed, but these are not saved to the output directory.
   ASL-reference-space CBF derivatives will automatically be generated if this level is selected.
+  Currently, 'minimal' and 'resampling' are effectively the same.
 * ``--level full``: This processing mode aims to produce all derivatives
   that have previously been a part of the ASLPrep output dataset.
   This is the default processing level.
@@ -179,7 +179,7 @@ FreeSurfer derivatives
 If FreeSurfer is run, then a FreeSurfer subjects directory is created in
 ``<output dir>/sourcedata/freesurfer`` or the directory indicated with the
 ``--fs-subjects-dir`` flag.
-Additionally, FreeSurfer segmentations are resampled into the BOLD space,
+Additionally, FreeSurfer segmentations are resampled into the ASL reference space,
 and lookup tables are provided. ::
 
     <output_dir>/


### PR DESCRIPTION
Closes none, but addresses a bug detected by @effigies.

In minimal mode, ASLPrep runs the CBF workflow, but doesn't currently write out the CBF derivatives. This is a bug. ASLPrep should write out aslref-space CBF derivatives no matter what, since they're the main output of interest.

## Changes proposed in this pull request

- Modify `init_ds_asl_native_wf` in the following ways:
    - Stop writing out the aslref-space ASL brain mask. This is handled by `init_asl_fit_wf`.
    - Write out CBF and ATT derivatives by default. Previously they were only written out if the parameter `asl_output` was True. Now, that parameter only determines if the aslref ASL file is written out.
- Move `init_ds_asl_native_wf` to before the workflow is returned when minimal mode is enabled.
- Call `init_ds_asl_native_wf` if aslref outputs are requested and full mode is enabled _or_ minimal/resampling mode is enabled. This way, if you're running in full mode and you don't want aslref outputs, you don't get them. However, if you're running in minimal or resampling mode, you get out aslref CBF and ATT outputs no matter what.