### PR TITLE
FIX: Change MCFLIRT cost function to Mutual Information

### DIFF
--- a/aslprep/workflows/asl/hmc.py
+++ b/aslprep/workflows/asl/hmc.py
@@ -131,7 +131,7 @@ re-calculated relative root mean-squared deviation.
     ])  # fmt:skip
 
     mcflirt = pe.MapNode(
-        fsl.MCFLIRT(save_mats=True, save_plots=True, save_rms=False),
+        fsl.MCFLIRT(save_mats=True, save_plots=True, save_rms=False, cost='mutualinfo'),
         name='mcflirt',
         mem_gb=mem_gb * 3,
         iterfield=['in_file'],


### PR DESCRIPTION
## Changes proposed in this pull request

Update MCFLIRT motion correction cost function to use mutual information. The default normcorr is not well suited to multi-delay data, see sub-issue #513.