### PR TITLE
Apply MCFLIRT to register m0scan to aslref image

### DIFF
--- a/aslprep/data/io_spec.json
+++ b/aslprep/data/io_spec.json
@@ -31,6 +31,14 @@
         "suffix": "xfm",
         "extension": ".txt"
       },
+      "m0scan2aslref": {
+        "datatype": "perf",
+        "from": "m0scan",
+        "to": "aslref",
+        "mode": "image",
+        "suffix": "xfm",
+        "extension": ".txt"
+      },
       "aslref2anat": {
         "datatype": "perf",
         "from": "aslref",

--- a/aslprep/data/reports-spec-asl.yml
+++ b/aslprep/data/reports-spec-asl.yml
@@ -92,6 +92,12 @@ sections:
       of performing SyN-based SDC on the ASL for comparison.
     static: false
     subtitle: Experimental fieldmap-less susceptibility distortion correction
+  - bids: {datatype: figures, desc: m0reg, suffix: asl, extension: [.svg]}
+    caption: |
+      The M0 scan was registered to the ASL reference using either an identity transform
+      (if the M0 scan is used to generate the ASL reference) or MCFLIRT.
+    static: false
+    subtitle: Alignment of ASL and M0 scans
   - bids: {datatype: figures, desc: flirtnobbr, suffix: asl, extension: [.svg]}
     caption: |
       <code>mri_coreg</code> (FreeSurfer) was used to generate transformations

--- a/aslprep/data/reports-spec.yml
+++ b/aslprep/data/reports-spec.yml
@@ -123,6 +123,12 @@ sections:
       of performing SyN-based SDC on the ASL for comparison.
     static: false
     subtitle: Experimental fieldmap-less susceptibility distortion correction
+  - bids: {datatype: figures, desc: m0reg, suffix: asl, extension: [.svg]}
+    caption: |
+      The M0 scan was registered to the ASL reference using either an identity transform
+      (if the M0 scan is used to generate the ASL reference) or MCFLIRT.
+    static: false
+    subtitle: Alignment of ASL and M0 scans
   - bids: {datatype: figures, desc: flirtnobbr, suffix: asl, extension: [.svg]}
     caption: |
       <code>mri_coreg</code> (FreeSurfer) was used to generate transformations

--- a/aslprep/interfaces/reference.py
+++ b/aslprep/interfaces/reference.py
@@ -34,18 +34,18 @@ class _SelectHighestContrastVolumesOutputSpec(TraitedSpec):
 
 
 class SelectHighestContrastVolumes(SimpleInterface):
-    """Apply the SCORE and SCRUB algorithms.
+    """Select the highest-contrast volume type for reference volume generation.
 
-    The Structural Correlation-based Outlier Rejection (SCORE) algorithm is applied to the CBF
-    time series to discard CBF volumes with outlying values :footcite:p:`dolui2017structural`
-    before computing the mean CBF.
-    The Structural Correlation with RobUst Bayesian (SCRUB) algorithm is then applied to the CBF
-    maps using structural tissue probability maps to reweight the mean CBF
-    :footcite:p:`dolui2016scrub`.
-
-    References
-    ----------
-    .. footbibliography::
+    This interface selects the highest-contrast volume type from the ASL context file and
+    returns a file containing the highest-contrast volumes.
+    The choice of volume type is based on a hard-coded priority list:
+    - Included M0 scan (if prioritized)
+    - Separate M0 scan (if prioritized)
+    - CBF
+    - DeltaM
+    - Included M0 scan (if not prioritized)
+    - Separate M0 scan (if not prioritized)
+    - Control
     """
 
     input_spec = _SelectHighestContrastVolumesInputSpec

--- a/aslprep/interfaces/utility.py
+++ b/aslprep/interfaces/utility.py
@@ -392,3 +392,26 @@ class IndexImage(NilearnBaseInterface, SimpleInterface):
         img_3d.to_filename(self._results['out_file'])
 
         return runtime
+
+
+class _GetImageTypeInputSpec(BaseInterfaceInputSpec):
+    image = File(exists=True, mandatory=True)
+
+
+class _GetImageTypeOutputSpec(TraitedSpec):
+    image_type = traits.Enum(0, 1, 2, 3)
+
+
+class GetImageType(SimpleInterface):
+    """Use to determine what to send to --input-image-type."""
+
+    input_spec = _GetImageTypeInputSpec
+    output_spec = _GetImageTypeOutputSpec
+
+    def _run_interface(self, runtime):
+        img = nb.load(self.inputs.image)
+        if img.ndim == 4:
+            self._results['image_type'] = 3
+        else:
+            self._results['image_type'] = 0
+        return runtime

--- a/aslprep/interfaces/utility.py
+++ b/aslprep/interfaces/utility.py
@@ -352,48 +352,43 @@ class Smooth(NilearnBaseInterface, SimpleInterface):
         return runtime
 
 
-class _ResampleToImageInputSpec(BaseInterfaceInputSpec):
+class _IndexImageInputSpec(BaseInterfaceInputSpec):
     in_file = File(
         exists=True,
         mandatory=True,
-        desc='An image to average over time.',
+        desc='A 4D image to index.',
     )
-    target_file = File(
-        exists=True,
-        mandatory=True,
-        desc='',
+    index = traits.Int(
+        0,
+        usedefault=True,
+        desc='Volume index to select from in_file.',
     )
     out_file = File(
-        'out_img.nii.gz',
+        'img_3d.nii.gz',
         usedefault=True,
         exists=False,
-        desc='The name of the resampled file to write out. out_img.nii.gz by default.',
+        desc='The name of the indexed file.',
     )
 
 
-class _ResampleToImageOutputSpec(TraitedSpec):
+class _IndexImageOutputSpec(TraitedSpec):
     out_file = File(
         exists=True,
-        desc='Resampled output file.',
+        desc='Concatenated output file.',
     )
 
 
-class ResampleToImage(NilearnBaseInterface, SimpleInterface):
-    """Resample a source image on a target image.
+class IndexImage(NilearnBaseInterface, SimpleInterface):
+    """Select a specific volume from a 4D image."""
 
-    No registration is performed: the image should already be aligned.
-    """
-
-    input_spec = _ResampleToImageInputSpec
-    output_spec = _ResampleToImageOutputSpec
+    input_spec = _IndexImageInputSpec
+    output_spec = _IndexImageOutputSpec
 
     def _run_interface(self, runtime):
-        from nilearn.image import resample_to_img
+        from nilearn.image import index_img
 
-        resampled_img = resample_to_img(
-            source_img=self.inputs.in_file,
-            target_img=self.inputs.target_file,
-            interpolation='continuous',
-        )
+        img_3d = index_img(self.inputs.in_file, self.inputs.index)
         self._results['out_file'] = os.path.join(runtime.cwd, self.inputs.out_file)
-        resampled_img.to_filename(self._results['out_file'])
+        img_3d.to_filename(self._results['out_file'])
+
+        return runtime

--- a/aslprep/interfaces/utility.py
+++ b/aslprep/interfaces/utility.py
@@ -431,6 +431,47 @@ class MeanImage(NilearnBaseInterface, SimpleInterface):
         return runtime
 
 
+class _Ensure4DInputSpec(BaseInterfaceInputSpec):
+    in_file = File(
+        exists=True,
+        mandatory=True,
+        desc='A 4D image to index.',
+    )
+    out_file = File(
+        'img_3d.nii.gz',
+        usedefault=True,
+        exists=False,
+        desc='The name of the indexed file.',
+    )
+
+
+class _Ensure4DOutputSpec(TraitedSpec):
+    out_file = File(
+        exists=True,
+        desc='Concatenated output file.',
+    )
+
+
+class Ensure4D(NilearnBaseInterface, SimpleInterface):
+    """Ensure a 4D image."""
+
+    input_spec = _Ensure4DInputSpec
+    output_spec = _Ensure4DOutputSpec
+
+    def _run_interface(self, runtime):
+        import nibabel as nb
+
+        img = nb.load(self.inputs.in_file)
+        if img.ndim == 3:
+            img = img.slicer[..., None]
+            self._results['out_file'] = os.path.join(runtime.cwd, self.inputs.out_file)
+            img.to_filename(self._results['out_file'])
+        else:
+            self._results['out_file'] = self.inputs.in_file
+
+        return runtime
+
+
 class _GetImageTypeInputSpec(BaseInterfaceInputSpec):
     image = File(exists=True, mandatory=True)
 

--- a/aslprep/interfaces/utility.py
+++ b/aslprep/interfaces/utility.py
@@ -350,3 +350,50 @@ class Smooth(NilearnBaseInterface, SimpleInterface):
         img_smoothed.to_filename(self._results['out_file'])
 
         return runtime
+
+
+class _ResampleToImageInputSpec(BaseInterfaceInputSpec):
+    in_file = File(
+        exists=True,
+        mandatory=True,
+        desc='An image to average over time.',
+    )
+    target_file = File(
+        exists=True,
+        mandatory=True,
+        desc='',
+    )
+    out_file = File(
+        'out_img.nii.gz',
+        usedefault=True,
+        exists=False,
+        desc='The name of the resampled file to write out. out_img.nii.gz by default.',
+    )
+
+
+class _ResampleToImageOutputSpec(TraitedSpec):
+    out_file = File(
+        exists=True,
+        desc='Resampled output file.',
+    )
+
+
+class ResampleToImage(NilearnBaseInterface, SimpleInterface):
+    """Resample a source image on a target image.
+
+    No registration is performed: the image should already be aligned.
+    """
+
+    input_spec = _ResampleToImageInputSpec
+    output_spec = _ResampleToImageOutputSpec
+
+    def _run_interface(self, runtime):
+        from nilearn.image import resample_to_img
+
+        resampled_img = resample_to_img(
+            source_img=self.inputs.in_file,
+            target_img=self.inputs.target_file,
+            interpolation='continuous',
+        )
+        self._results['out_file'] = os.path.join(runtime.cwd, self.inputs.out_file)
+        resampled_img.to_filename(self._results['out_file'])

--- a/aslprep/interfaces/utility.py
+++ b/aslprep/interfaces/utility.py
@@ -394,6 +394,43 @@ class IndexImage(NilearnBaseInterface, SimpleInterface):
         return runtime
 
 
+class _MeanImageInputSpec(BaseInterfaceInputSpec):
+    in_file = File(
+        exists=True,
+        mandatory=True,
+        desc='A 4D image to index.',
+    )
+    out_file = File(
+        'img_3d.nii.gz',
+        usedefault=True,
+        exists=False,
+        desc='The name of the indexed file.',
+    )
+
+
+class _MeanImageOutputSpec(TraitedSpec):
+    out_file = File(
+        exists=True,
+        desc='Concatenated output file.',
+    )
+
+
+class MeanImage(NilearnBaseInterface, SimpleInterface):
+    """Calculate the mean image of a 4D image."""
+
+    input_spec = _MeanImageInputSpec
+    output_spec = _MeanImageOutputSpec
+
+    def _run_interface(self, runtime):
+        from nilearn.image import mean_img
+
+        img_mean = mean_img(self.inputs.in_file)
+        self._results['out_file'] = os.path.join(runtime.cwd, self.inputs.out_file)
+        img_mean.to_filename(self._results['out_file'])
+
+        return runtime
+
+
 class _GetImageTypeInputSpec(BaseInterfaceInputSpec):
     image = File(exists=True, mandatory=True)
 

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_multipld.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_multipld.txt
@@ -193,5 +193,6 @@ sub-01/perf/sub-01_desc-preproc_asl.nii.gz
 sub-01/perf/sub-01_desc-qualitycontrol_cbf.tsv
 sub-01/perf/sub-01_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/perf/sub-01_from-aslref_to-T1w_mode-image_xfm.txt
+sub-01/perf/sub-01_from-m0scan_to-aslref_mode-image_xfm.txt
 sub-01/perf/sub-01_from-orig_to-aslref_mode-image_xfm.json
 sub-01/perf/sub-01_from-orig_to-aslref_mode-image_xfm.txt

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_philips.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_philips.txt
@@ -230,6 +230,7 @@ sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-timeseries_cbf.json
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_desc-timeseries_cbf.nii.gz
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_from-aslref_to-T1w_mode-image_xfm.txt
+sub-01/ses-philips2d/perf/sub-01_ses-philips2d_from-m0scan_to-aslref_mode-image_xfm.txt
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_from-orig_to-aslref_mode-image_xfm.json
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_from-orig_to-aslref_mode-image_xfm.txt
 sub-01/ses-philips2d/perf/sub-01_ses-philips2d_hemi-L_space-fsaverage5_cbf.func.gii

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_siemens.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_siemens.txt
@@ -190,6 +190,7 @@ sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_desc-hmc_aslref.nii.gz
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_desc-qualitycontrol_cbf.tsv
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_from-aslref_to-T1w_mode-image_xfm.txt
+sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_from-m0scan_to-aslref_mode-image_xfm.txt
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_from-orig_to-aslref_mode-image_xfm.json
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_from-orig_to-aslref_mode-image_xfm.txt
 sub-01/ses-siemens3d/perf/sub-01_ses-siemens3d_space-MNI152NLin2009cAsym_aslref.nii.gz

--- a/aslprep/tests/data/expected_outputs_test_002.txt
+++ b/aslprep/tests/data/expected_outputs_test_002.txt
@@ -135,6 +135,7 @@ sub-01/perf/sub-01_desc-timeseries_cbf.json
 sub-01/perf/sub-01_desc-timeseries_cbf.nii.gz
 sub-01/perf/sub-01_from-aslref_to-T1w_mode-image_xfm.json
 sub-01/perf/sub-01_from-aslref_to-T1w_mode-image_xfm.txt
+sub-01/perf/sub-01_from-m0scan_to-aslref_mode-image_xfm.txt
 sub-01/perf/sub-01_from-orig_to-aslref_mode-image_xfm.json
 sub-01/perf/sub-01_from-orig_to-aslref_mode-image_xfm.txt
 sub-01/perf/sub-01_space-MNI152NLin2009cAsym_aslref.nii.gz

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -322,6 +322,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
     # Perform minimal preprocessing of the ASL data, including HMC and SDC
     asl_fit_wf = init_asl_fit_wf(
         asl_file=asl_file,
+        aslcontext=run_data['aslcontext'],
         m0scan=run_data['m0scan'],
         use_ge=use_ge,
         precomputed=precomputed,
@@ -332,7 +333,6 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
 
     workflow.connect([
         (inputnode, asl_fit_wf, [
-            ('aslcontext', 'inputnode.aslcontext'),
             # Original inputs from fMRIPrep
             ('t1w_preproc', 'inputnode.t1w_preproc'),
             ('t1w_mask', 'inputnode.t1w_mask'),
@@ -373,6 +373,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
             ('outputnode.asl_mask', 'inputnode.asl_mask'),
             ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
             ('outputnode.aslref2fmap_xfm', 'inputnode.aslref2fmap_xfm'),
+            ('outputnode.m0scan2aslref_xfm', 'inputnode.m0scan2aslref_xfm'),
         ]),
     ])  # fmt:skip
 

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -120,6 +120,7 @@ def init_cbf_wf(
     workflow = Workflow(name=name)
 
     workflow.__desc__ = """
+
 Cerebral blood flow computation and denoising
 
 """

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -509,7 +509,9 @@ def init_asl_fit_wf(
             from niworkflows import data as nw_data
 
             # XXX: What about multiple M0 scans?
-            m0scanreg_buffer.inputs.m0scan2aslref_xfm = nw_data.load('itkIdentityTransform.txt')
+            m0scanreg_buffer.inputs.m0scan2aslref_xfm = str(
+                nw_data.load('itkIdentityTransform.txt')
+            )
         else:
             from nipype.interfaces import fsl
             from niworkflows.interfaces.itk import MCFLIRT2ITK

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -359,7 +359,7 @@ def init_asl_fit_wf(
     asl_fit_reports_wf = init_asl_fit_reports_wf(
         # TODO: Enable sdc report even if we find coregref
         sdc_correction=fieldmap_id is not None,
-        separate_m0scan=m0scan,
+        separate_m0scan=m0scan is not None,
         freesurfer=config.workflow.run_reconall,
         output_dir=config.execution.aslprep_dir,
     )

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -510,7 +510,7 @@ def init_asl_fit_wf(
         # By using MCFLIRT, we can support 4D M0 scans.
         # Register the M0 scan to the ASL reference.
         mcflirt = pe.Node(
-            fsl.MCFLIRT(cost='mutualinfo'),
+            fsl.MCFLIRT(save_mats=True, cost='mutualinfo'),
             name='mcflirt',
             mem_gb=mem_gb['filesize'],
         )

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -536,7 +536,7 @@ def init_asl_fit_wf(
         ds_m0scan2aslref_xfm = pe.Node(
             DerivativesDataSink(
                 base_dir=config.execution.aslprep_dir,
-                source_file=m0scan,
+                source_file=str(m0scan),
                 datatype='perf',
                 suffix='xfm',
                 extension='.txt',

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -526,7 +526,7 @@ def init_asl_fit_wf(
             mem_gb=mem_gb['filesize'],
         )
         workflow.connect([
-            (mcflirt, mean_m0scan, [('mean_img', 'in_file')]),
+            (mcflirt, mean_m0scan, [('out_file', 'in_file')]),
             (mean_m0scan, asl_fit_reports_wf, [('out_file', 'inputnode.m0scan_aslref')]),
         ])  # fmt:skip
 

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -359,7 +359,7 @@ def init_asl_fit_wf(
     asl_fit_reports_wf = init_asl_fit_reports_wf(
         # TODO: Enable sdc report even if we find coregref
         sdc_correction=fieldmap_id is not None,
-        separate_m0scan=m0scan and (reference_volume_type != 'separate_m0scan'),
+        separate_m0scan=m0scan,
         freesurfer=config.workflow.run_reconall,
         output_dir=config.execution.aslprep_dir,
     )

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -539,6 +539,10 @@ def init_asl_fit_wf(
 
         fsl2itk = pe.Node(MCFLIRT2ITK(), name='fsl2itk', mem_gb=0.05, n_procs=omp_nthreads)
         workflow.connect([
+            (hmcref_buffer, fsl2itk, [
+                ('aslref', 'in_source'),
+                ('aslref', 'in_reference'),
+            ]),
             (mcflirt, fsl2itk, [('mat_file', 'in_files')]),
             (fsl2itk, m0scanreg_buffer, [('out_file', 'm0scan2aslref_xfm')]),
         ])  # fmt:skip

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -535,8 +535,8 @@ def init_asl_fit_wf(
 
         ds_m0scan2aslref_xfm = pe.Node(
             DerivativesDataSink(
-                base_dir=config.execution.aslprep_dir,
-                source_file=str(m0scan),
+                base_directory=config.execution.aslprep_dir,
+                source_file=m0scan,
                 datatype='perf',
                 suffix='xfm',
                 extension='.txt',

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -269,6 +269,8 @@ def init_asl_fit_wf(
         name='inputnode',
     )
     inputnode.inputs.asl_file = asl_file
+    inputnode.inputs.aslcontext = aslcontext
+    inputnode.inputs.m0scan = m0scan
 
     outputnode = pe.Node(
         niu.IdentityInterface(

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -501,11 +501,8 @@ def init_asl_fit_wf(
         from aslprep.interfaces.bids import DerivativesDataSink
 
         config.loggers.workflow.info('Stage 2b: Adding M0 scan registration workflow')
-        # If we have a separate M0 scan, we need to register it to the ASL reference.
-        # If the reference_volume_type is separate_m0scan, the aslref is the separate M0 scan,
-        # so we should use the identity transform.
-        # Otherwise, we need to register the M0 scan to the ASL reference.
         if reference_volume_type == 'separate_m0scan':
+            # The separate M0 scan *is* the ASL reference, so we can use the identity transform.
             from niworkflows import data as nw_data
 
             # XXX: What about multiple M0 scans?
@@ -513,6 +510,8 @@ def init_asl_fit_wf(
                 nw_data.load('itkIdentityTransform.txt')
             )
         else:
+            # Register the M0 scan to the ASL reference.
+            # By using MCFLIRT, we can support 4D M0 scans.
             from nipype.interfaces import fsl
             from niworkflows.interfaces.itk import MCFLIRT2ITK
 

--- a/aslprep/workflows/asl/outputs.py
+++ b/aslprep/workflows/asl/outputs.py
@@ -153,6 +153,7 @@ def prepare_timing_parameters(metadata: dict):
 def init_asl_fit_reports_wf(
     *,
     sdc_correction: bool,
+    separate_m0scan: bool,
     freesurfer: bool,  # noqa:U100
     output_dir: str,
     name='asl_fit_reports_wf',
@@ -165,6 +166,10 @@ def init_asl_fit_reports_wf(
 
     Parameters
     ----------
+    sdc_correction : :obj:`bool`
+        Whether SDC correction was performed or not.
+    separate_m0scan : :obj:`bool`
+        Whether a separate M0 scan was used or not.
     freesurfer : :obj:`bool`
         FreeSurfer was enabled
     output_dir : :obj:`str`
@@ -208,6 +213,7 @@ def init_asl_fit_reports_wf(
         'source_file',
         'sdc_aslref',
         'coreg_aslref',
+        'm0scan_aslref',
         'aslref2anat_xfm',
         'aslref2fmap_xfm',
         't1w_preproc',
@@ -312,6 +318,9 @@ def init_asl_fit_reports_wf(
     # - SDC2:
     #       Before: Pre-SDC aslref with white matter mask
     #       After: Post-SDC aslref with white matter mask
+    # - M0-ASL registration (if applicable):
+    #       Before: M0 scan
+    #       After: ASL reference
     # - ASL-T1 registration:
     #       Before: T1w brain with white matter mask
     #       After: Resampled aslref with white matter mask
@@ -412,6 +421,42 @@ def init_asl_fit_reports_wf(
             (aslref_wm, sdc_report, [('output_image', 'wm_seg')]),
             (inputnode, ds_sdc_report, [('source_file', 'source_file')]),
             (sdc_report, ds_sdc_report, [('out_report', 'in_file')]),
+        ])  # fmt:skip
+
+    # M0-ASL registration
+    #       Before: M0 scan
+    #       After: ASL reference
+
+    if separate_m0scan:
+        m0_asl_report = pe.Node(
+            SimpleBeforeAfter(
+                before_label='M0',
+                after_label='ASL',
+                dismiss_affine=True,
+            ),
+            name='m0_asl_report',
+            mem_gb=0.1,
+        )
+
+        ds_m0_asl_report = pe.Node(
+            DerivativesDataSink(
+                base_directory=output_dir,
+                desc='m0reg',
+                suffix='asl',
+                datatype='figures',
+                dismiss_entities=('echo',),
+            ),
+            name='ds_m0_asl_report',
+        )
+
+        workflow.connect([
+            (inputnode, m0_asl_report, [
+                ('m0scan_aslref', 'before'),
+                ('coreg_aslref', 'after'),
+            ]),
+            (aslref_wm, m0_asl_report, [('output_image', 'wm_seg')]),
+            (inputnode, ds_m0_asl_report, [('source_file', 'source_file')]),
+            (m0_asl_report, ds_m0_asl_report, [('out_report', 'in_file')]),
         ])  # fmt:skip
 
     # ASL-T1 registration

--- a/aslprep/workflows/asl/reference.py
+++ b/aslprep/workflows/asl/reference.py
@@ -87,8 +87,9 @@ def init_raw_aslref_wf(
         Number of non-steady-state volumes algorithmically detected at
         beginning of ``asl_file``
     """
-    from nipype.interfaces.afni.utils import Resample
     from niworkflows.interfaces.images import RobustAverage
+
+    from aslprep.interfaces.utility import ResampleToImage
 
     workflow = Workflow(name=name)
     workflow.__desc__ = """\
@@ -145,11 +146,11 @@ for use in head motion correction.
         # In some cases, the separate M0 scan may have a different resolution than the ASL scan.
         # We resample the M0 scan to match the ASL scan at this point.
         resample_m0scan_to_asl = pe.Node(
-            Resample(outputtype='NIFTI'),
+            ResampleToImage(),
             name='resample_m0scan_to_asl',
         )
         workflow.connect([
-            (val_asl, resample_m0scan_to_asl, [('out_file', 'master')]),
+            (val_asl, resample_m0scan_to_asl, [('out_file', 'target_file')]),
             (val_m0scan, resample_m0scan_to_asl, [('out_file', 'in_file')]),
         ])  # fmt:skip
 

--- a/aslprep/workflows/asl/reference.py
+++ b/aslprep/workflows/asl/reference.py
@@ -90,6 +90,7 @@ def init_raw_aslref_wf(
     from niworkflows.interfaces.images import RobustAverage
 
     from aslprep.interfaces.ants import ApplyTransforms
+    from aslprep.interfaces.utility import IndexImage
 
     workflow = Workflow(name=name)
     workflow.__desc__ = """\
@@ -143,6 +144,13 @@ for use in head motion correction.
         )
         workflow.connect([(inputnode, val_m0scan, [('m0scan', 'in_file')])])
 
+        # Grab first volume of ASL file
+        extract_3d_asl = pe.Node(
+            IndexImage(index=0),
+            name='extract_3d_asl',
+        )
+        workflow.connect([(val_asl, extract_3d_asl, [('out_file', 'in_file')])])
+
         # In some cases, the separate M0 scan may have a different resolution than the ASL scan.
         # We resample the M0 scan to match the ASL scan at this point.
         resample_m0scan_to_asl = pe.Node(
@@ -154,7 +162,7 @@ for use in head motion correction.
             name='resample_m0scan_to_asl',
         )
         workflow.connect([
-            (val_asl, resample_m0scan_to_asl, [('out_file', 'reference_image')]),
+            (extract_3d_asl, resample_m0scan_to_asl, [('out_file', 'reference_image')]),
             (val_m0scan, resample_m0scan_to_asl, [('out_file', 'input_image')]),
         ])  # fmt:skip
 

--- a/aslprep/workflows/asl/reference.py
+++ b/aslprep/workflows/asl/reference.py
@@ -93,9 +93,9 @@ def init_raw_aslref_wf(
     from aslprep.interfaces.utility import GetImageType, IndexImage
 
     workflow = Workflow(name=name)
-    workflow.__desc__ = """\
-First, a reference volume was generated using a custom methodology of *ASLPrep*,
-for use in head motion correction.
+    workflow.__desc__ = f"""\
+First, a reference volume was generated from the {reference_volume_type} volumes using a custom
+methodology of *ASLPrep*, for use in head motion correction.
 """
 
     inputnode = pe.Node(

--- a/aslprep/workflows/asl/reference.py
+++ b/aslprep/workflows/asl/reference.py
@@ -149,6 +149,7 @@ for use in head motion correction.
             ApplyTransforms(
                 interpolation='Gaussian',
                 transforms=['identity'],
+                args='--verbose',
             ),
             name='resample_m0scan_to_asl',
         )

--- a/aslprep/workflows/asl/reference.py
+++ b/aslprep/workflows/asl/reference.py
@@ -90,7 +90,7 @@ def init_raw_aslref_wf(
     from niworkflows.interfaces.images import RobustAverage
 
     from aslprep.interfaces.ants import ApplyTransforms
-    from aslprep.interfaces.utility import IndexImage
+    from aslprep.interfaces.utility import GetImageType, IndexImage
 
     workflow = Workflow(name=name)
     workflow.__desc__ = """\
@@ -153,6 +153,9 @@ for use in head motion correction.
 
         # In some cases, the separate M0 scan may have a different resolution than the ASL scan.
         # We resample the M0 scan to match the ASL scan at this point.
+        get_image_type = pe.Node(GetImageType(), name='get_image_type')
+        workflow.connect([(val_m0scan, get_image_type, [('out_file', 'image')])])
+
         resample_m0scan_to_asl = pe.Node(
             ApplyTransforms(
                 interpolation='Gaussian',
@@ -164,6 +167,7 @@ for use in head motion correction.
         workflow.connect([
             (extract_3d_asl, resample_m0scan_to_asl, [('out_file', 'reference_image')]),
             (val_m0scan, resample_m0scan_to_asl, [('out_file', 'input_image')]),
+            (get_image_type, resample_m0scan_to_asl, [('image_type', 'input_image_type')]),
         ])  # fmt:skip
 
     select_highest_contrast_volumes = pe.Node(

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -178,7 +178,7 @@ Head-motion estimation
    )
 
 Using the previously estimated reference scan,
-FSL ``mcflirt`` or AFNI ``3dvolreg`` is used to estimate head-motion.
+FSL ``mcflirt`` is used to estimate head-motion.
 As a result, one rigid-body transform with respect to
 the reference image is written for each :abbr:`ASL (Arterial Spin Labelling)`
 time-step.


### PR DESCRIPTION
Closes #550.

## Changes proposed in this pull request

- Generate and write out a new transform, `<source_entities>_from-m0scan_to-aslref_mode-image_xfm.txt`, to register a separate M0 scan to the ASL reference image. If the separate M0 scan is used as the reference image, then this will be an identity transform.
    - What if there are multiple M0 volumes in the separate M0 scan file, the separate M0 scan is used as the reference image, and there's motion? We should probably run MCFLIRT to the first volume and write that out as the transform, right?