### PR TITLE
Fix typos in report specifications

### DIFF
--- a/aslprep/data/reports-spec-asl.yml
+++ b/aslprep/data/reports-spec-asl.yml
@@ -100,7 +100,7 @@ sections:
       highlight potential spin-history and other artifacts, whereas final images are
       resampled using Lanczos interpolation.
     static: false
-    subtitle: Alignment of functional and anatomical MRI data (volume based)
+    subtitle: Alignment of perfusion and anatomical MRI data (volume based)
   - bids: {datatype: figures, desc: coreg, suffix: asl, extension: [.svg]}
     caption: |
       <code>mri_coreg</code> (FreeSurfer) was used to generate transformations
@@ -109,7 +109,7 @@ sections:
       potential spin-history and other artifacts, whereas final images are resampled
       using Lanczos interpolation.
     static: false
-    subtitle: Alignment of functional and anatomical MRI data (volume based)
+    subtitle: Alignment of perfusion and anatomical MRI data (volume based)
   - bids: {datatype: figures, desc: flirtbbr, suffix: asl, extension: [.svg]}
     caption: |
       FSL <code>flirt</code> was used to generate transformations from ASL-space
@@ -118,7 +118,7 @@ sections:
       is used in the reportlets in order to highlight potential spin-history and other
       artifacts, whereas final images are resampled using Lanczos interpolation.
     static: false
-    subtitle: Alignment of functional and anatomical MRI data (surface driven)
+    subtitle: Alignment of perfusion and anatomical MRI data (surface driven)
   - bids: {datatype: figures, desc: bbregister, suffix: asl, extension: [.svg]}
     caption: |
       <code>bbregister</code> was used to generate transformations from ASL-space
@@ -126,7 +126,7 @@ sections:
       in order to highlight potential spin-history and other artifacts, whereas final
       images are resampled using Lanczos interpolation.
     static: false
-    subtitle: Alignment of functional and anatomical MRI data (surface driven)
+    subtitle: Alignment of perfusion and anatomical MRI data (surface driven)
   - bids: {datatype: figures, desc: rois, suffix: asl, extension: [.svg]}
     caption: |
       Brain mask calculated on the ASL signal (red contour), along with the

--- a/aslprep/data/reports-spec.yml
+++ b/aslprep/data/reports-spec.yml
@@ -131,7 +131,7 @@ sections:
       highlight potential spin-history and other artifacts, whereas final images are
       resampled using Lanczos interpolation.
     static: false
-    subtitle: Alignment of functional and anatomical MRI data (volume based)
+    subtitle: Alignment of perfusion and anatomical MRI data (volume based)
   - bids: {datatype: figures, desc: coreg, suffix: asl, extension: [.svg]}
     caption: |
       <code>mri_coreg</code> (FreeSurfer) was used to generate transformations
@@ -140,7 +140,7 @@ sections:
       potential spin-history and other artifacts, whereas final images are resampled
       using Lanczos interpolation.
     static: false
-    subtitle: Alignment of functional and anatomical MRI data (volume based)
+    subtitle: Alignment of perfusion and anatomical MRI data (volume based)
   - bids: {datatype: figures, desc: flirtbbr, suffix: asl, extension: [.svg]}
     caption: |
       FSL <code>flirt</code> was used to generate transformations from ASL-space
@@ -149,7 +149,7 @@ sections:
       is used in the reportlets in order to highlight potential spin-history and other
       artifacts, whereas final images are resampled using Lanczos interpolation.
     static: false
-    subtitle: Alignment of functional and anatomical MRI data (surface driven)
+    subtitle: Alignment of perfusion and anatomical MRI data (surface driven)
   - bids: {datatype: figures, desc: bbregister, suffix: asl, extension: [.svg]}
     caption: |
       <code>bbregister</code> was used to generate transformations from ASL-space
@@ -157,7 +157,7 @@ sections:
       in order to highlight potential spin-history and other artifacts, whereas final
       images are resampled using Lanczos interpolation.
     static: false
-    subtitle: Alignment of functional and anatomical MRI data (surface driven)
+    subtitle: Alignment of perfusion and anatomical MRI data (surface driven)
   - bids: {datatype: figures, desc: rois, suffix: asl, extension: [.svg]}
     caption: |
       Brain mask calculated on the ASL signal (red contour), along with the


### PR DESCRIPTION
Closes none, but relates to #500.

## Changes proposed in this pull request

- Replace "functional" with "perfusion" in HTML reportlet descriptions.