### PR TITLE
Allow duplicate keys in `get_sbrefs`

### DIFF
--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -79,7 +79,8 @@ def get_sbrefs(
         sorted by EchoTime
     """
     entities = extract_entities(asl_file)
-    entities.update(suffix='sbref', extension=['.nii', '.nii.gz'], **entity_overrides)
+    entities.update(suffix='sbref', extension=['.nii', '.nii.gz'])
+    entities.update(entity_overrides)
 
     return layout.get(return_type='file', **entities)
 


### PR DESCRIPTION
Closes none. This should only affect runs where the user provided a BIDS filter file that included an `sbref` field, even though sbrefs aren't supported in ASL data yet.

## Changes proposed in this pull request

- Base `get_sbrefs` on fMRIPrep.