### PR TITLE
Resample M0 scan to ASL resolution

### DIFF
--- a/aslprep/data/reports-spec-asl.yml
+++ b/aslprep/data/reports-spec-asl.yml
@@ -96,6 +96,9 @@ sections:
     caption: |
       The M0 scan was registered to the ASL reference using either an identity transform
       (if the M0 scan is used to generate the ASL reference) or MCFLIRT.
+
+      This plot compares the HMC-transformed M0 scan to the ASL reference after distortion correction,
+      so there may be some mismatch due to SDC.
     static: false
     subtitle: Alignment of ASL and M0 scans
   - bids: {datatype: figures, desc: flirtnobbr, suffix: asl, extension: [.svg]}

--- a/aslprep/data/reports-spec.yml
+++ b/aslprep/data/reports-spec.yml
@@ -127,6 +127,9 @@ sections:
     caption: |
       The M0 scan was registered to the ASL reference using either an identity transform
       (if the M0 scan is used to generate the ASL reference) or MCFLIRT.
+
+      This plot compares the HMC-transformed M0 scan to the ASL reference after distortion correction,
+      so there may be some mismatch due to SDC.
     static: false
     subtitle: Alignment of ASL and M0 scans
   - bids: {datatype: figures, desc: flirtnobbr, suffix: asl, extension: [.svg]}

--- a/aslprep/interfaces/utility.py
+++ b/aslprep/interfaces/utility.py
@@ -431,6 +431,43 @@ class MeanImage(NilearnBaseInterface, SimpleInterface):
         return runtime
 
 
+class _Ensure4DInputSpec(BaseInterfaceInputSpec):
+    in_file = File(
+        exists=True,
+        mandatory=True,
+        desc='A 4D image to index.',
+    )
+    out_file = File(
+        'img_4d.nii.gz',
+        usedefault=True,
+        exists=False,
+        desc='The name of the 4D file.',
+    )
+
+
+class _Ensure4DOutputSpec(TraitedSpec):
+    out_file = File(
+        exists=True,
+        desc='The name of the 4D file.',
+    )
+
+
+class Ensure4D(NilearnBaseInterface, SimpleInterface):
+    """Ensure a 4D image."""
+
+    input_spec = _Ensure4DInputSpec
+    output_spec = _Ensure4DOutputSpec
+
+    def _run_interface(self, runtime):
+        from nilearn._utils.niimg_conversions import check_niimg_4d
+
+        img4d = check_niimg_4d(self.inputs.in_file)
+        self._results['out_file'] = os.path.join(runtime.cwd, self.inputs.out_file)
+        img4d.to_filename(self._results['out_file'])
+
+        return runtime
+
+
 class _GetImageTypeInputSpec(BaseInterfaceInputSpec):
     image = File(exists=True, mandatory=True)
 

--- a/aslprep/interfaces/utility.py
+++ b/aslprep/interfaces/utility.py
@@ -438,17 +438,17 @@ class _Ensure4DInputSpec(BaseInterfaceInputSpec):
         desc='A 4D image to index.',
     )
     out_file = File(
-        'img_3d.nii.gz',
+        'img_4d.nii.gz',
         usedefault=True,
         exists=False,
-        desc='The name of the indexed file.',
+        desc='The name of the 4D file.',
     )
 
 
 class _Ensure4DOutputSpec(TraitedSpec):
     out_file = File(
         exists=True,
-        desc='Concatenated output file.',
+        desc='The name of the 4D file.',
     )
 
 

--- a/aslprep/interfaces/utility.py
+++ b/aslprep/interfaces/utility.py
@@ -459,15 +459,11 @@ class Ensure4D(NilearnBaseInterface, SimpleInterface):
     output_spec = _Ensure4DOutputSpec
 
     def _run_interface(self, runtime):
-        import nibabel as nb
+        from nilearn._utils.niimg_conversions import check_niimg_4d
 
-        img = nb.load(self.inputs.in_file)
-        if img.ndim == 3:
-            img = img.slicer[..., None]
-            self._results['out_file'] = os.path.join(runtime.cwd, self.inputs.out_file)
-            img.to_filename(self._results['out_file'])
-        else:
-            self._results['out_file'] = self.inputs.in_file
+        img4d = check_niimg_4d(self.inputs.in_file)
+        self._results['out_file'] = os.path.join(runtime.cwd, self.inputs.out_file)
+        img4d.to_filename(self._results['out_file'])
 
         return runtime
 

--- a/aslprep/interfaces/utility.py
+++ b/aslprep/interfaces/utility.py
@@ -431,43 +431,6 @@ class MeanImage(NilearnBaseInterface, SimpleInterface):
         return runtime
 
 
-class _Ensure4DInputSpec(BaseInterfaceInputSpec):
-    in_file = File(
-        exists=True,
-        mandatory=True,
-        desc='A 4D image to index.',
-    )
-    out_file = File(
-        'img_4d.nii.gz',
-        usedefault=True,
-        exists=False,
-        desc='The name of the 4D file.',
-    )
-
-
-class _Ensure4DOutputSpec(TraitedSpec):
-    out_file = File(
-        exists=True,
-        desc='The name of the 4D file.',
-    )
-
-
-class Ensure4D(NilearnBaseInterface, SimpleInterface):
-    """Ensure a 4D image."""
-
-    input_spec = _Ensure4DInputSpec
-    output_spec = _Ensure4DOutputSpec
-
-    def _run_interface(self, runtime):
-        from nilearn._utils.niimg_conversions import check_niimg_4d
-
-        img4d = check_niimg_4d(self.inputs.in_file)
-        self._results['out_file'] = os.path.join(runtime.cwd, self.inputs.out_file)
-        img4d.to_filename(self._results['out_file'])
-
-        return runtime
-
-
 class _GetImageTypeInputSpec(BaseInterfaceInputSpec):
     image = File(exists=True, mandatory=True)
 

--- a/aslprep/interfaces/utility.py
+++ b/aslprep/interfaces/utility.py
@@ -459,11 +459,15 @@ class Ensure4D(NilearnBaseInterface, SimpleInterface):
     output_spec = _Ensure4DOutputSpec
 
     def _run_interface(self, runtime):
-        from nilearn._utils.niimg_conversions import check_niimg_4d
+        import nibabel as nb
 
-        img4d = check_niimg_4d(self.inputs.in_file)
-        self._results['out_file'] = os.path.join(runtime.cwd, self.inputs.out_file)
-        img4d.to_filename(self._results['out_file'])
+        img = nb.load(self.inputs.in_file)
+        if img.ndim == 3:
+            img = img.slicer[..., None]
+            self._results['out_file'] = os.path.join(runtime.cwd, self.inputs.out_file)
+            img.to_filename(self._results['out_file'])
+        else:
+            self._results['out_file'] = self.inputs.in_file
 
         return runtime
 

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -986,6 +986,7 @@ def init_asl_native_wf(
         # Resample separate M0 file to aslref resolution/orientation
         resample_m0scan_to_asl = pe.Node(
             ApplyTransforms(
+                dimension=4,
                 interpolation='Gaussian',
                 transforms=['identity'],
                 args='--verbose',

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -1001,7 +1001,6 @@ def init_asl_native_wf(
         aslref_m0scan = pe.Node(
             ResampleSeries(
                 jacobian=jacobian,
-                in_file=m0scan,
             ),
             name='aslref_m0scan',
             n_procs=omp_nthreads,
@@ -1011,6 +1010,7 @@ def init_asl_native_wf(
                 ('aslref', 'ref_file'),
                 ('m0scan2aslref_xfm', 'transforms'),
             ]),
+            (resample_m0scan_to_asl, aslref_m0scan, [('output_image', 'in_file')]),
             (aslbuffer, aslref_m0scan, [
                 ('ro_time', 'ro_time'),
                 ('pe_dir', 'pe_dir'),

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -987,6 +987,7 @@ def init_asl_native_wf(
         resample_m0scan_to_asl = pe.Node(
             ApplyTransforms(
                 dimension=4,
+                input_image_type=3,
                 interpolation='Gaussian',
                 transforms=['identity'],
                 args='--verbose',

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -986,7 +986,6 @@ def init_asl_native_wf(
         # Resample separate M0 file to aslref resolution/orientation
         resample_m0scan_to_asl = pe.Node(
             ApplyTransforms(
-                dimension=4,
                 input_image_type=3,
                 interpolation='Gaussian',
                 transforms=['identity'],

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -498,7 +498,7 @@ def init_asl_fit_wf(
         config.loggers.workflow.info('Found motion correction transforms - skipping Stage 2')
 
     # Stage 2b: Register M0 scan to aslref
-    if m0scan and not hmc_xforms:
+    if m0scan and not m0scan2aslref_xform:
         from aslprep.workflows.asl.hmc import init_m0scan_hmc_wf
 
         config.loggers.workflow.info('Stage 2b: Adding M0 scan registration workflow')

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -498,73 +498,29 @@ def init_asl_fit_wf(
         config.loggers.workflow.info('Found motion correction transforms - skipping Stage 2')
 
     # Stage 2b: Register M0 scan to aslref
-    if m0scan:
-        from nipype.interfaces import fsl
-        from niworkflows.interfaces.itk import MCFLIRT2ITK
-
-        from aslprep.interfaces.bids import DerivativesDataSink
-        from aslprep.interfaces.utility import Ensure4D, MeanImage
+    if m0scan and not hmc_xforms:
+        from aslprep.workflows.asl.hmc import init_m0scan_hmc_wf
 
         config.loggers.workflow.info('Stage 2b: Adding M0 scan registration workflow')
 
-        # Ensure M0 scan is 4D
-        ensure_4d = pe.Node(
-            Ensure4D(),
-            name='ensure_4d',
-        )
-        workflow.connect([(inputnode, ensure_4d, [('m0scan', 'in_file')])])
-
-        # Register the M0 scan to the ASL reference.
-        # By using MCFLIRT, we can support 4D M0 scans.
-        # Register the M0 scan to the ASL reference.
-        mcflirt = pe.Node(
-            fsl.MCFLIRT(save_mats=True, cost='mutualinfo'),
-            name='mcflirt',
+        m0scan_hmc_wf = init_m0scan_hmc_wf(
+            output_dir=config.execution.aslprep_dir,
             mem_gb=mem_gb['filesize'],
+            omp_nthreads=omp_nthreads,
+            name='m0scan_hmc_wf',
         )
         workflow.connect([
-            (ensure_4d, mcflirt, [('out_file', 'in_file')]),
-            (hmcref_buffer, mcflirt, [('aslref', 'ref_file')]),
-        ])  # fmt:skip
-
-        # Calculate mean image of M0 scan
-        mean_m0scan = pe.Node(
-            MeanImage(),
-            name='mean_m0scan',
-            mem_gb=mem_gb['filesize'],
-        )
-        workflow.connect([
-            (mcflirt, mean_m0scan, [('out_file', 'in_file')]),
-            (mean_m0scan, asl_fit_reports_wf, [('out_file', 'inputnode.m0scan_aslref')]),
-        ])  # fmt:skip
-
-        fsl2itk = pe.Node(MCFLIRT2ITK(), name='fsl2itk', mem_gb=0.05, n_procs=omp_nthreads)
-        workflow.connect([
-            (hmcref_buffer, fsl2itk, [
-                ('aslref', 'in_source'),
-                ('aslref', 'in_reference'),
+            (inputnode, m0scan_hmc_wf, [('m0scan', 'inputnode.m0scan')]),
+            (hmcref_buffer, m0scan_hmc_wf, [('aslref', 'inputnode.aslref')]),
+            (m0scan_hmc_wf, m0scanreg_buffer, [
+                ('outputnode.m0scan2aslref_xfm', 'm0scan2aslref_xfm'),
             ]),
-            (mcflirt, fsl2itk, [('mat_file', 'in_files')]),
-            (fsl2itk, m0scanreg_buffer, [('out_file', 'm0scan2aslref_xfm')]),
+            (m0scan_hmc_wf, asl_fit_reports_wf, [
+                ('outputnode.m0scan_aslref', 'inputnode.m0scan_aslref'),
+            ]),
         ])  # fmt:skip
-
-        ds_m0scan2aslref_xfm = pe.Node(
-            DerivativesDataSink(
-                base_directory=config.execution.aslprep_dir,
-                source_file=m0scan,
-                datatype='perf',
-                suffix='xfm',
-                extension='.txt',
-                **{
-                    'from': 'm0scan',
-                    'to': 'aslref',
-                },
-            ),
-            name='ds_m0scan2aslref_xfm',
-        )
-        workflow.connect([
-            (m0scanreg_buffer, ds_m0scan2aslref_xfm, [('m0scan2aslref_xfm', 'in_file')]),
-        ])  # fmt:skip
+    elif m0scan:
+        config.loggers.workflow.info('Found M0 motion correction transforms - skipping Stage 2b')
 
     # Stage 3: Register fieldmap to aslref and reconstruct in ASL space
     if fieldmap_id:
@@ -888,6 +844,8 @@ def init_asl_native_wf(
         For multi-echo data, motion correction has already been applied, so
         this will be undefined.
     """
+    from aslprep.interfaces.ants import ApplyTransforms
+    from aslprep.interfaces.utility import Ensure4D
     from aslprep.utils.misc import estimate_asl_mem_usage
 
     layout = config.execution.layout
@@ -1018,7 +976,28 @@ def init_asl_native_wf(
     ])  # fmt:skip
 
     if m0scan:
-        # Resample separate M0 file to aslref
+        # Ensure M0 scan is 4D
+        ensure_4d = pe.Node(
+            Ensure4D(),
+            name='ensure_4d',
+        )
+        workflow.connect([(inputnode, ensure_4d, [('m0scan', 'in_file')])])
+
+        # Resample separate M0 file to aslref resolution/orientation
+        resample_m0scan_to_asl = pe.Node(
+            ApplyTransforms(
+                interpolation='Gaussian',
+                transforms=['identity'],
+                args='--verbose',
+            ),
+            name='resample_m0scan_to_asl',
+        )
+        workflow.connect([
+            (inputnode, resample_m0scan_to_asl, [('aslref', 'reference_image')]),
+            (ensure_4d, resample_m0scan_to_asl, [('out_file', 'input_image')]),
+        ])  # fmt:skip
+
+        # Apply transforms to M0 scan to aslref space
         aslref_m0scan = pe.Node(
             ResampleSeries(
                 jacobian=jacobian,
@@ -1027,7 +1006,6 @@ def init_asl_native_wf(
             name='aslref_m0scan',
             n_procs=omp_nthreads,
         )
-
         workflow.connect([
             (inputnode, aslref_m0scan, [
                 ('aslref', 'ref_file'),
@@ -1055,6 +1033,8 @@ def init_asl_native_wf(
         ])  # fmt:skip
 
         if m0scan:
+            # This assumes that the M0 scan and the ASL file have the same distortion.
+            # In some edge cases, that might not be true.
             workflow.connect([(aslref_fmap, aslref_m0scan, [('out_file', 'fieldmap')])])
 
     workflow.connect([

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -874,6 +874,7 @@ def init_asl_native_wf(
         ),
         name='inputnode',
     )
+    inputnode.inputs.m0scan = m0scan
 
     outputnode = pe.Node(
         niu.IdentityInterface(

--- a/aslprep/workflows/asl/hmc.py
+++ b/aslprep/workflows/asl/hmc.py
@@ -289,6 +289,7 @@ def init_m0scan_hmc_wf(
     # Resample M0 scan to ASL reference resolution/orientation
     resample_m0scan_to_asl = pe.Node(
         ApplyTransforms(
+            dimension=4,
             interpolation='Gaussian',
             transforms=['identity'],
             args='--verbose',

--- a/aslprep/workflows/asl/hmc.py
+++ b/aslprep/workflows/asl/hmc.py
@@ -290,6 +290,7 @@ def init_m0scan_hmc_wf(
     resample_m0scan_to_asl = pe.Node(
         ApplyTransforms(
             dimension=4,
+            input_image_type=3,
             interpolation='Gaussian',
             transforms=['identity'],
             args='--verbose',

--- a/aslprep/workflows/asl/hmc.py
+++ b/aslprep/workflows/asl/hmc.py
@@ -255,7 +255,7 @@ def init_m0scan_hmc_wf(
 
     from aslprep.interfaces.ants import ApplyTransforms
     from aslprep.interfaces.bids import DerivativesDataSink
-    from aslprep.interfaces.utility import GetImageType, MeanImage
+    from aslprep.interfaces.utility import Ensure4D, GetImageType, MeanImage
 
     workflow = Workflow(name=name)
 
@@ -301,6 +301,9 @@ def init_m0scan_hmc_wf(
         (get_image_type, resample_m0scan_to_asl, [('image_type', 'input_image_type')]),
     ])  # fmt:skip
 
+    ensure_4d = pe.Node(Ensure4D(), name='ensure_4d')
+    workflow.connect([(resample_m0scan_to_asl, ensure_4d, [('output_image', 'in_file')])])
+
     # Register the M0 scan to the ASL reference.
     # By using MCFLIRT, we can support 4D M0 scans.
     # Register the M0 scan to the ASL reference.
@@ -311,7 +314,7 @@ def init_m0scan_hmc_wf(
     )
     workflow.connect([
         (inputnode, mcflirt, [('aslref', 'ref_file')]),
-        (resample_m0scan_to_asl, mcflirt, [('output_image', 'in_file')]),
+        (ensure_4d, mcflirt, [('out_file', 'in_file')]),
     ])  # fmt:skip
 
     # Calculate mean image of M0 scan

--- a/aslprep/workflows/asl/hmc.py
+++ b/aslprep/workflows/asl/hmc.py
@@ -289,7 +289,6 @@ def init_m0scan_hmc_wf(
     # Resample M0 scan to ASL reference resolution/orientation
     resample_m0scan_to_asl = pe.Node(
         ApplyTransforms(
-            dimension=4,
             input_image_type=3,
             interpolation='Gaussian',
             transforms=['identity'],

--- a/aslprep/workflows/asl/hmc.py
+++ b/aslprep/workflows/asl/hmc.py
@@ -209,12 +209,25 @@ def init_m0scan_hmc_wf(
     This workflow resamples the M0 scan to the ASL reference resolution/orientation,
     and then applies MCFLIRT to the M0 scan.
 
+    Workflow Graph
+        .. workflow::
+            :graph2use: orig
+            :simple_form: yes
+
+            from aslprep.workflows.asl.hmc import init_m0scan_hmc_wf
+
+            wf = init_m0scan_hmc_wf(
+                mem_gb=3,
+                omp_nthreads=1,
+                name="asl_hmc_wf",
+            )
+
     Parameters
     ----------
     output_dir : :obj:`str`
         Output directory for the M0 scan motion correction transforms
     mem_gb : :obj:`float`
-        Size of M0 scan in GB
+        Memory usage for the workflow in GB.
     omp_nthreads : :obj:`int`
         Maximum number of threads an individual process may use
     name : :obj:`str`
@@ -293,7 +306,7 @@ def init_m0scan_hmc_wf(
     mcflirt = pe.Node(
         fsl.MCFLIRT(save_mats=True, cost='mutualinfo'),
         name='mcflirt',
-        mem_gb=mem_gb['filesize'],
+        mem_gb=mem_gb,
     )
     workflow.connect([
         (inputnode, mcflirt, [('aslref', 'ref_file')]),
@@ -304,7 +317,7 @@ def init_m0scan_hmc_wf(
     mean_m0scan = pe.Node(
         MeanImage(),
         name='mean_m0scan',
-        mem_gb=mem_gb['filesize'],
+        mem_gb=mem_gb,
     )
     workflow.connect([
         (mcflirt, mean_m0scan, [('out_file', 'in_file')]),

--- a/aslprep/workflows/asl/hmc.py
+++ b/aslprep/workflows/asl/hmc.py
@@ -310,7 +310,7 @@ def init_m0scan_hmc_wf(
     )
     workflow.connect([
         (inputnode, mcflirt, [('aslref', 'ref_file')]),
-        (resample_m0scan_to_asl, mcflirt, [('out_file', 'in_file')]),
+        (resample_m0scan_to_asl, mcflirt, [('output_image', 'in_file')]),
     ])  # fmt:skip
 
     # Calculate mean image of M0 scan


### PR DESCRIPTION
Closes none, but continues work from #553.

## Changes proposed in this pull request

- Move M0 HMC steps into new workflow, `init_m0scan_hmc_wf`.
- Only calculate m0scan2aslref_xfm if the transform isn't part of the precomputed derivatives (`init_asl_fit_wf`).
- Resample the M0 scan to the same resolution/orientation as the ASL reference image before applying the  `m0scan2aslref_xfm` (`init_asl_native_wf`).