### PR TITLE
Fix tau array generation for multi-delay data

### DIFF
--- a/aslprep/utils/cbf.py
+++ b/aslprep/utils/cbf.py
@@ -1076,7 +1076,7 @@ def fit_deltam_multipld(
         if isinstance(tau, float):
             tau = np.full((n_volumes,), tau)
         else:
-            tau = np.ndarray(tau)
+            tau = np.array(tau)
 
             if tau.size != n_volumes:
                 raise ValueError(


### PR DESCRIPTION
Closes #567.

## Changes proposed in this pull request

- I was using `np.ndarray`, which accepts a list of dimension sizes to create an ND array of zeros, like `np.zeros`. I should have been using `np.array`, which converts the list to an array.
