### PR TITLE
Use anatomical brain mask for ASL data

### DIFF
--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -739,8 +739,6 @@ def init_asl_fit_wf(
                 ('fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
             ]),
             (regref_buffer, asl_reg_wf, [('aslref', 'inputnode.ref_bold_brain')]),
-            # Incomplete sources
-            (regref_buffer, ds_aslreg_wf, [('aslref', 'inputnode.source_files')]),
             (asl_reg_wf, ds_aslreg_wf, [('outputnode.itk_bold_to_t1', 'inputnode.xform')]),
             (ds_aslreg_wf, outputnode, [('outputnode.xform', 'aslref2anat_xfm')]),
             (asl_reg_wf, summary, [('outputnode.fallback', 'fallback')]),


### PR DESCRIPTION
The anatomical brain mask is reliably more accurate than those estimated by the aslref. The aslref can have many different contrasts depending on what data is available, and not all perform well with the asl-based skull stripping workflow.

This workflow resamples the T1 brain mask into aslref space instead of estimating one using the ASL. It turns out this is ok to do because the coregistration does not use masked ASL data.