### PR TITLE
Remove MIDB and Myers-Labonte atlases

### DIFF
--- a/aslprep/utils/atlas.py
+++ b/aslprep/utils/atlas.py
@@ -33,8 +33,6 @@ def select_atlases(atlases, subset):
             '4S1056Parcels',
             'Glasser',
             'Gordon',
-            'MIDB',
-            'MyersLabonte',
         ],
         'subcortical': [
             'Tian',


### PR DESCRIPTION
Closes none. I accidentally added these in #603.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `MIDB` and `MyersLabonte` from the builtin cortical atlases (and thus from `all`).
> 
> - **Atlases selection (`aslprep/utils/atlas.py`)**:
>   - Remove `MIDB` and `MyersLabonte` from builtin `cortical` atlases.
>   - `all` aggregation updates accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd032e037d2f9342d4658b5e32552fbd34182407. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->