### PR TITLE
Account for cases with separate M0 scan and precomputed CBF in reference workflow

### DIFF
--- a/aslprep/workflows/asl/reference.py
+++ b/aslprep/workflows/asl/reference.py
@@ -179,7 +179,8 @@ methodology of *ASLPrep*, for use in head motion correction.
         (inputnode, select_highest_contrast_volumes, [('aslcontext', 'aslcontext')]),
         (val_asl, select_highest_contrast_volumes, [('out_file', 'asl_file')]),
     ])  # fmt:skip
-    if m0scan:
+
+    if m0scan and reference_volume_type == 'separate_m0scan':
         workflow.connect([
             (resample_m0scan_to_asl, select_highest_contrast_volumes, [
                 ('output_image', 'm0scan'),


### PR DESCRIPTION
Closes none, but addresses a bug I came across while testing #605.

In cases where the ASL scan has a separate M0 scan, but also there are precomputed CBF or deltaM volumes in the ASL scan, the precomputed CBF/deltaM volumes will be chosen to make the ASL reference image, rather than the separate M0 scan. However, there is a step to resample the separate M0 scan to the same resolution as the ASL scan, which should only be included in the reference workflow if it's going to be used as the ASL reference. That node was being referenced anyway, hence the bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only connect the resampled separate M0 scan to volume selection when `reference_volume_type == 'separate_m0scan'`, avoiding invalid node references when using precomputed CBF/deltaM.
> 
> - **ASL reference workflow (`aslprep/workflows/asl/reference.py`)**:
>   - Condition the connection of `resample_m0scan_to_asl -> select_highest_contrast_volumes(m0scan)` on `m0scan` AND `reference_volume_type == 'separate_m0scan'`.
>   - Ensures M0 resampling is only used when separate M0 is the chosen reference type, preventing unintended use when CBF/deltaM volumes are selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f352275320fa18fc4d605adbecc0dfb6d73e9fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->