### PR TITLE
Re-use collected asl mask in fit workflow

### DIFF
--- a/aslprep/data/io_spec.json
+++ b/aslprep/data/io_spec.json
@@ -54,6 +54,18 @@
         "suffix": "xfm",
         "extension": ".txt"
       }
+    },
+    "masks": {
+      "aslref": {
+        "datatype": "perf",
+        "space": null,
+        "desc": "brain",
+        "suffix": "mask",
+        "extension": [
+          ".nii.gz",
+          ".nii"
+        ]
+      }
     }
   },
   "patterns": [

--- a/aslprep/utils/bids.py
+++ b/aslprep/utils/bids.py
@@ -138,6 +138,15 @@ def collect_derivatives(
             continue
         transforms_cache[xfm] = item[0] if len(item) == 1 else item
     derivs_cache['transforms'] = transforms_cache
+
+    for k, q in spec['masks'].items():
+        query = {**entities, **q}
+        item = layout.get(return_type='filename', **query)
+        if not item or len(item) != 1:
+            continue
+
+        derivs_cache[k] = item[0]
+
     return derivs_cache
 
 

--- a/aslprep/workflows/asl/fit.py
+++ b/aslprep/workflows/asl/fit.py
@@ -243,6 +243,7 @@ def init_asl_fit_wf(
     aslref2fmap_xform = transforms.get('aslref2fmap')
     aslref2anat_xform = transforms.get('aslref2anat')
     m0scan2aslref_xform = transforms.get('m0scan2aslref')
+    aslref_mask = precomputed.get('aslref_mask')
 
     workflow = Workflow(name=name)
 
@@ -312,8 +313,12 @@ def init_asl_fit_wf(
         name='fmapreg_buffer',
     )
     regref_buffer = pe.Node(
-        niu.IdentityInterface(fields=['aslref', 'aslmask']),
+        niu.IdentityInterface(fields=['aslref']),
         name='regref_buffer',
+    )
+    aslmask_buffer = pe.Node(
+        niu.IdentityInterface(fields=['aslmask']),
+        name='aslmask_buffer',
     )
 
     if hmc_aslref:
@@ -334,6 +339,9 @@ def init_asl_fit_wf(
     if coreg_aslref:
         regref_buffer.inputs.aslref = coreg_aslref
         config.loggers.workflow.debug('Reusing coregistration reference: %s', coreg_aslref)
+    if aslref_mask:
+        aslmask_buffer.inputs.aslmask = aslref_mask
+        config.loggers.workflow.debug('Reusing ASL reference mask: %s', aslref_mask)
     fmapref_buffer.inputs.sbref_files = sbref_files
 
     summary = pe.Node(
@@ -368,10 +376,8 @@ def init_asl_fit_wf(
     workflow.connect([
         (hmcref_buffer, fmapref_buffer, [('aslref', 'aslref_files')]),
         (hmcref_buffer, outputnode, [('aslref', 'hmc_aslref')]),
-        (regref_buffer, outputnode, [
-            ('aslref', 'coreg_aslref'),
-            ('aslmask', 'asl_mask'),
-        ]),
+        (regref_buffer, outputnode, [('aslref', 'coreg_aslref')]),
+        (aslmask_buffer, outputnode, [('aslmask', 'asl_mask')]),
         (fmapreg_buffer, outputnode, [('aslref2fmap_xfm', 'aslref2fmap_xfm')]),
         (hmc_buffer, outputnode, [('hmc_xforms', 'motion_xfm')]),
         (m0scanreg_buffer, outputnode, [('m0scan2aslref_xfm', 'm0scan2aslref_xfm')]),
@@ -640,7 +646,7 @@ def init_asl_fit_wf(
                 ('in_file', 'inputnode.source_files'),
             ]),
             (ds_coreg_aslref_wf, regref_buffer, [('outputnode.aslref', 'aslref')]),
-            (ds_aslmask_wf, regref_buffer, [('outputnode.boldmask', 'aslmask')]),
+            (ds_aslmask_wf, aslmask_buffer, [('outputnode.boldmask', 'aslmask')]),
         ])  # fmt:skip
 
         if fieldmap_id:
@@ -705,7 +711,7 @@ def init_asl_fit_wf(
         skullstrip_precomp_ref_wf = init_skullstrip_bold_wf(name='skullstrip_precomp_ref_wf')
         skullstrip_precomp_ref_wf.inputs.inputnode.in_file = coreg_aslref
         workflow.connect([
-            (skullstrip_precomp_ref_wf, regref_buffer, [('outputnode.mask_file', 'aslmask')])
+            (skullstrip_precomp_ref_wf, aslmask_buffer, [('outputnode.mask_file', 'aslmask')])
         ])  # fmt:skip
 
     # Stage 5: Register ASL to anatomical space


### PR DESCRIPTION
Re-implements some of #601.

## Changes proposed in this pull request

- Collect the precomputed aslref-space mask.