### PR TITLE
Change extra deps group from test to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ runinstall: &runinstall
     git checkout $CIRCLE_BRANCH
     echo "${VERSION}" > /src/aslprep/aslprep/VERSION
     echo "include aslprep/VERSION" >> /src/aslprep/MANIFEST.in
-    pip install .[test] --progress-bar off
+    pip install .[tests] --progress-bar off
 
     # Write the config file
     mkdir ~/.nipype

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
     "ruff ~= 0.15.0",
     "pre-commit",
 ]
-test = [
+tests = [
     "codecov",
     "coverage",
     "pytest",
@@ -87,7 +87,7 @@ maint = [
 ]
 
 # Aliases
-all = ["aslprep[dev,doc,maint,test]"]
+all = ["aslprep[dev,doc,maint,tests]"]
 
 [project.scripts]
 aslprep = "aslprep.cli.run:main"


### PR DESCRIPTION
Closes none.

## Changes proposed in this pull request

- Change `test` dependency group in pyproject.toml to `tests`, to match XCP-D, QSIPrep, and QSIRecon.
