### PR TITLE
Port CircleCI improvements over from XCP-D

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - build-v1-{{ .Branch }}-{{ .Revision }}
+            - build-v3-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
       - restore_cache:
           keys:
             - data-v1-{{ .Branch }}-{{ .Revision }}
@@ -116,11 +116,9 @@ jobs:
           path: /tmp/src/aslprep
       - restore_cache:
           keys:
+            - build-v3-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
             - build-v1-{{ .Branch }}-{{ .Revision }}
-            - build-v1--{{ .Revision }}
-            - build-v1-{{ .Branch }}-
             - build-v1-main-
-            - build-v1-
       - run: *docker_auth
       - run: *setup_docker_registry
       - run:
@@ -135,40 +133,13 @@ jobs:
       - run:
           name: Determine whether image builds are required
           command: |
-            # Always build images on main/tags for deploy correctness.
-            if [[ -n "$CIRCLE_TAG" || "$CIRCLE_BRANCH" == "main" ]]; then
-              echo "BUILD_PRODUCTION_IMAGE=1" >> "$BASH_ENV"
-              echo "BUILD_TEST_IMAGE=1" >> "$BASH_ENV"
-              exit 0
-            fi
-
-            # Prefer per-commit diffs so old branch history does not trigger
-            # repeated rebuilds on unrelated follow-up commits.
-            if git rev-parse --verify HEAD~1 > /dev/null 2>&1; then
-              CHANGED_FILES="$(git diff --name-only HEAD~1 HEAD)"
-            else
-              # Fallback for shallow/special histories.
-              if ! git fetch --no-tags --depth=200 origin main; then
-                echo "Could not fetch origin/main; defaulting to image builds."
-                echo "BUILD_PRODUCTION_IMAGE=1" >> "$BASH_ENV"
-                echo "BUILD_TEST_IMAGE=1" >> "$BASH_ENV"
-                exit 0
-              fi
-              if ! MERGE_BASE="$(git merge-base HEAD origin/main)"; then
-                echo "Could not compute merge-base; defaulting to image builds."
-                echo "BUILD_PRODUCTION_IMAGE=1" >> "$BASH_ENV"
-                echo "BUILD_TEST_IMAGE=1" >> "$BASH_ENV"
-                exit 0
-              fi
-              CHANGED_FILES="$(git diff --name-only "$MERGE_BASE" HEAD)"
-            fi
-
-            if printf "%s\n" "$CHANGED_FILES" | rg -q "^(Dockerfile\\.base|Dockerfile|pixi\\.lock)$"; then
-              echo "BUILD_PRODUCTION_IMAGE=1" >> "$BASH_ENV"
-              echo "BUILD_TEST_IMAGE=1" >> "$BASH_ENV"
-            else
+            if [[ -f /tmp/images/imageprep-success.marker ]]; then
               echo "BUILD_PRODUCTION_IMAGE=0" >> "$BASH_ENV"
               echo "BUILD_TEST_IMAGE=0" >> "$BASH_ENV"
+            else
+              echo "No successful cached image prep for current Docker inputs; rebuilding images."
+              echo "BUILD_PRODUCTION_IMAGE=1" >> "$BASH_ENV"
+              echo "BUILD_TEST_IMAGE=1" >> "$BASH_ENV"
             fi
       - run:
           name: Build base image if needed
@@ -243,7 +214,7 @@ jobs:
       - run:
           name: Push base image to Docker Hub (if newly built)
           command: |
-            if docker image inspect $BASE_IMAGE > /dev/null 2>&1; then
+            if [[ "$BASE_WAS_BUILT" == "1" ]] && docker image inspect $BASE_IMAGE > /dev/null 2>&1; then
               if [[ -n "$DOCKERHUB_TOKEN" ]]; then
                 docker push $BASE_IMAGE
                 docker push $BASE_IMAGE_NAME:latest
@@ -262,10 +233,16 @@ jobs:
       - run:
           name: Docker registry garbage collection
           command: |
-            docker exec -it registry /bin/registry garbage-collect --delete-untagged \
+            docker exec registry /bin/registry garbage-collect --delete-untagged \
               /etc/docker/registry/config.yml
+      - run:
+          name: Record successful image prep
+          command: |
+            mkdir -p /tmp/images
+            touch /tmp/images/imageprep-success.marker
+            docker save registry:2 -o /tmp/images/registry.tar.gz
       - save_cache:
-          key: build-v1-{{ .Branch }}-{{ .Revision }}
+          key: build-v3-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
           paths:
             - /tmp/docker
             - /tmp/images
@@ -581,7 +558,7 @@ jobs:
           path: /tmp/src/aslprep
       - restore_cache:
           keys:
-            - build-v1-{{ .Branch }}-{{ .Revision }}
+            - build-v3-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
       - run: *docker_auth
       - run: *setup_docker_registry
       - run: *pull_from_registry

--- a/.github/workflows/pixi-lock.yml
+++ b/.github/workflows/pixi-lock.yml
@@ -17,7 +17,19 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+      - name: Check latest commit for dependency edits
+        id: latest-commit
+        run: |
+          CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r HEAD)"
+          echo "$CHANGED_FILES"
+          if echo "$CHANGED_FILES" | grep -Eq '^(pyproject\.toml|pixi\.lock)$'; then
+            echo "run_lockfile_update=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_lockfile_update=false" >> "$GITHUB_OUTPUT"
+            echo "Latest commit did not touch pyproject.toml or pixi.lock; skipping lockfile update."
+          fi
       - name: Find submitting repository
+        if: ${{ steps.latest-commit.outputs.run_lockfile_update == 'true' }}
         id: get-source-repo
         uses: actions/github-script@v8
         env:
@@ -34,20 +46,25 @@ jobs:
             core.setOutput('remote', data.head.repo.html_url)
             core.setOutput('branch', data.head.ref)
       - name: Set git identity
+        if: ${{ steps.latest-commit.outputs.run_lockfile_update == 'true' }}
         run: |
           git config --global user.name "nipreps[bot]"
           git config --global user.email "bot@nipreps.org"
       - uses: prefix-dev/setup-pixi@v0.9.4
+        if: ${{ steps.latest-commit.outputs.run_lockfile_update == 'true' }}
         with:
           pixi-version: v0.58.0
           run-install: false
       - name: Install the latest version of uv
+        if: ${{ steps.latest-commit.outputs.run_lockfile_update == 'true' }}
         uses: astral-sh/setup-uv@v7
       - name: Update lockfile
+        if: ${{ steps.latest-commit.outputs.run_lockfile_update == 'true' }}
         run: >
           uvx datalad run -i pixi.lock -i pyproject.toml -o pixi.lock --
-          bash -c '! pixi lock --check || git checkout .'
+          bash -lc "if pixi lock --check; then echo 'Lockfile up to date'; else pixi lock; fi"
       - name: Push updated lockfile, if needed
+        if: ${{ steps.latest-commit.outputs.run_lockfile_update == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           git push $REMOTE HEAD:$BRANCH
         env:

--- a/.maint/ASLPREP_VS_FMRIPREP.md
+++ b/.maint/ASLPREP_VS_FMRIPREP.md
@@ -1,6 +1,6 @@
 # Packaging and maintenance: ASLPrep vs fMRIPrep
 
-This document summarizes how ASLPrep’s packaging and maintenance compare to fMRIPrep after the alignment work.
+This document summarizes how ASLPrep’s packaging and maintenance compare to fMRIPrep.
 
 ---
 
@@ -11,19 +11,13 @@ This document summarizes how ASLPrep’s packaging and maintenance compare to fM
   - **Main image** built from `Dockerfile` that uses Pixi to build the Python environment, then assembles the final image on top of the base.
 - **Pixi dependency management**
   - Both use `pyproject.toml` + `pixi.lock` for unified conda + PyPI dependency resolution.
-  - Base image has no Python stack; the main Dockerfile builds the environment via Pixi.
+  - Both use a multi-stage Docker build with Pixi environments and a template prefetch stage.
 - **Date-based base image tags**
-  - Both use date-stamped tags (e.g. `fmriprep-base:20251006`, `aslprep-base:20260219`), updated only when the base changes. CI builds the base only if the tagged image is missing from the registry.
-- **CI test architecture**
-  - Both use machine executors in CI: build the Docker image first (production + test targets), save to a local registry, then run tests via `docker run` inside the built test image. Tests execute in the exact same environment that ships.
-- **Layout**
-  - `docker/files/` (e.g. FreeSurfer exclude list), `scripts/fetch_templates.py`.
-- **.dockerignore**
-  - Present in both to keep build context small.
-- **.maint**
-  - Both have `update_authors.py`, `update_ignore_revs.sh`, CONTRIBUTORS/MAINTAINERS/FORMER/PIs. fMRIPrep additionally has `update_changes.sh`. ASLPrep has extra docs (HOW_WE_WORK, ROADMAP, etc.).
+  - Both use date-stamped base tags, and CI only rebuilds the base image when the referenced tag is missing in the registry.
+- **Maintenance scaffolding**
+  - Both include `.maint/update_authors.py`, `.maint/update_ignore_revs.sh`, and maintainer tables (`CONTRIBUTORS.md`, `MAINTAINERS.md`, `PIs.md`, `FORMER.md`).
 - **Release flow**
-  - Version in CITATION.cff, optional Zenodo/authors update, tag → build/push images, GitHub Release.
+  - Both rely on version tags + CI image publication and GitHub Releases.
 
 ---
 
@@ -31,13 +25,16 @@ This document summarizes how ASLPrep’s packaging and maintenance compare to fM
 
 | Area | fMRIPrep | ASLPrep |
 |------|----------|--------|
-| **Docker CI** | GitHub Actions (`.github/workflows/docker.yml`): build base if missing, then build and push main to **ghcr.io**. | **CircleCI**: `build` job builds base if missing, builds production + test images, saves to local registry; `deploy_docker` pushes to **Docker Hub**. Tests run via `docker run` inside the built test image (same pattern as fMRIPrep). No GHA Docker workflow. |
-| **Docker registry** | **ghcr.io** (e.g. `ghcr.io/nipreps/fmriprep`, `ghcr.io/nipreps/fmriprep-base`). | **Docker Hub** (`pennlinc/aslprep`, `pennlinc/aslprep-base`). |
-| **Docker wrapper** | **fmriprep-docker** package under `wrapper/` for a CLI that runs `docker run` with the right mounts. | **None**; users run `docker run` (or equivalent) directly. |
-| **Changelog for releases** | Changelog file in repo + release notes from it / labels (`update_changes.sh`). | **GitHub release notes only** (labels + “Generate release notes”); no changelog file or update step. |
+| **Container CI platform** | GitHub Actions (`.github/workflows/docker.yml`) builds base/main images and publishes to GHCR on non-PR events. | CircleCI (`.circleci/config.yml`) builds `image_prep` + test image/cache flow and publishes via `deploy_docker`. |
+| **Container registry** | **ghcr.io** (`ghcr.io/nipreps/fmriprep`, `ghcr.io/nipreps/fmriprep-base`). | **Docker Hub** (`pennlinc/aslprep`, `pennlinc/aslprep-base`). |
+| **Lockfile automation trigger** | `pixi-lock.yml` runs lockfile update steps on every `pull_request_target` and attempts push-back unconditionally. | `pixi-lock.yml` now gates lockfile updates to latest-commit edits of `pyproject.toml` / `pixi.lock` and only pushes on same-repo PRs. |
+| **Image rebuild trigger logic** | Buildx cache behavior in GHA Docker workflow; no CircleCI-style marker cache key. | `image_prep` rebuild trigger keyed to `Dockerfile` + `pixi.lock` checksum cache (`build-v3`) and `imageprep-success.marker`. |
+| **Testing execution model in CI** | Primary test workflow (`.github/workflows/test.yml`) runs tox on Python matrices; Docker workflow is focused on image builds. | CircleCI runs integration/unit tests by invoking `pytest` inside the built `pennlinc/aslprep:test` image. |
+| **Docker wrapper package** | Includes `wrapper/` (`fmriprep-docker`) for a helper CLI around `docker run`. | No analogous wrapper package in this repository. |
+| **Changelog tooling** | Includes `.maint/update_changes.sh`. | No equivalent changelog-maintenance script in `.maint`. |
 
 ---
 
 ## Summary
 
-ASLPrep now matches fMRIPrep’s **structure** (base + main Dockerfiles, Pixi dependency management, date-based base image tags, machine-executor CI with `docker run` testing, `.maint` scripts, no wrapper), but keeps **CircleCI** (not GHA) for Docker build/deploy, **Docker Hub** (not ghcr.io), and **GitHub release notes as the sole changelog** for releases.
+ASLPrep and fMRIPrep are now closely aligned on Docker/Pixi structure and base-image maintenance strategy, but they still differ in CI stack (CircleCI vs GitHub Actions), registry target (Docker Hub vs GHCR), and lockfile/test orchestration details.

--- a/.maint/INSTRUCTIONS.md
+++ b/.maint/INSTRUCTIONS.md
@@ -24,12 +24,11 @@ These change rarely and live outside the pixi ecosystem.
    ARG BASE_IMAGE=pennlinc/aslprep-base:<YYYYMMDD>
    ```
 
-3. **Commit and push.** The CI `build_and_deploy` job runs
-   `docker manifest inspect` against the new tag. Since the image does not exist
-   yet, it will build `Dockerfile.base`, push it with the date tag and `latest`,
-   then build the main image on top of it.
+3. **Commit and push.** The CircleCI `image_prep` job checks whether the new base
+   image tag exists. If not, it builds `Dockerfile.base`, pushes the date tag and
+   `latest`, then builds the main image on top of it.
 
-4. **Verify** the CI `build_and_deploy` job succeeds and the new base image
+4. **Verify** the CI image jobs succeed and the new base image
    appears on Docker Hub at `pennlinc/aslprep-base:<YYYYMMDD>`.
 
 For local testing:
@@ -60,15 +59,20 @@ Both are resolved together by pixi when generating `pixi.lock`.
 
 2. **Commit and open a pull request.**
 
-3. **The `pixi-lock.yml` GitHub Action runs automatically** on the PR. It checks
-   whether `pixi.lock` is stale and, if so, regenerates it and pushes the
-   updated lockfile back to the PR branch.
+3. **The `pixi-lock.yml` GitHub Action runs automatically** on every
+   `pull_request_target` event. It checks whether the latest commit touched
+   `pyproject.toml` or `pixi.lock` and only then runs lockfile update steps.
 
-4. **Review the lockfile update.** Because `pixi.lock` is marked as binary in
+4. **Lockfile push behavior depends on PR source:**
+   - **Same-repo branch PRs:** the workflow pushes updated `pixi.lock` back to the PR branch.
+   - **Fork PRs:** the workflow does **not** push (by design). In this case, update
+     `pixi.lock` manually in a Linux environment and push from the contributor branch.
+
+5. **Review the lockfile update.** Because `pixi.lock` is marked as binary in
    `.gitattributes`, GitHub will not render a diff. You can inspect locally with
    `git diff HEAD~1 -- pixi.lock` if needed.
 
-5. **Merge the PR** once CI passes.
+6. **Merge the PR** once CI passes.
 
 > **Note:** `pixi lock` only runs on Linux (the project specifies
 > `platforms = ["linux-64"]`). You cannot regenerate the lockfile locally on
@@ -128,6 +132,105 @@ a Linux machine** because the project only targets `linux-64`.
 
 ---
 
+## CI workflow trigger conditions
+
+This section explains what causes each CI workflow step/job to run.
+In this repository, file changes only control a subset of behavior.
+
+### GitHub Action: `.github/workflows/pixi-lock.yml`
+
+The workflow is triggered on every `pull_request_target` event. Inside the job:
+
+- **Always runs**
+  - `Checkout pull request`
+  - `Check latest commit for dependency edits`
+- **Runs only if the latest commit touched one of these root files**
+  - `pyproject.toml`
+  - `pixi.lock`
+  - Conditional steps:
+    - `Find submitting repository`
+    - `Set git identity`
+    - `prefix-dev/setup-pixi`
+    - `Install the latest version of uv`
+    - `Update lockfile`
+- **Pushes updated lockfile only when both are true**
+  - Latest commit touched `pyproject.toml` or `pixi.lock`
+  - PR source branch is in this same repository (not a fork)
+
+Practical implication: editing other files alone still starts the workflow,
+but lockfile update steps are skipped.
+
+### CircleCI: `.circleci/config.yml`
+
+CircleCI does **not** use file path filters in this config. Jobs are selected by
+workflow filters (branch/tag) and can be halted by commit-message markers.
+
+#### Branch/tag filters that control job execution
+
+- `image_prep`: runs on all branches and all tags.
+- `get_data`, integration jobs, `pytests`, `merge_coverage`:
+  - Run on all tags.
+  - Run on branches except names matching `docs?/.*` or `tests?/.*`.
+- `deployable` and `deploy_docker`:
+  - Run on `main` and on all tags.
+
+#### Commit-message markers that halt jobs
+
+- Integration jobs stop early if latest commit message contains a job-specific
+  marker such as `[skip qtab]`, `[skip test_001]`, or
+  `[skip examples_pcasl_singlepld_philips]` (case-insensitive with `_` support).
+- `pytests` stops early if latest commit message contains
+  `[skip pytests]` or `[skip_pytests]` (case-insensitive).
+
+#### File changes that indirectly affect CircleCI behavior
+
+These files are used in the `build-v3` cache key:
+
+- `Dockerfile`
+- `pixi.lock`
+
+Changing either of them changes the cache key and invalidates the prior
+`imageprep-success.marker`, so `image_prep` sets:
+
+- `BUILD_PRODUCTION_IMAGE=1`
+- `BUILD_TEST_IMAGE=1`
+
+That means the production and test image build steps run. Base image rebuild is
+controlled separately by whether the `BASE_IMAGE` tag in `Dockerfile` already
+exists in Docker Hub.
+
+#### `image_prep` rebuild matrix (by file edit)
+
+- **Edit `Dockerfile` and change `ARG BASE_IMAGE=...` to a new/missing tag**
+  - Base image: **rebuilt** (`Dockerfile.base` build runs because manifest is missing)
+  - Production image: **rebuilt**
+  - Test image: **rebuilt**
+- **Edit `Dockerfile` without changing `BASE_IMAGE` tag**
+  - Base image: rebuilt **only if** current `BASE_IMAGE` tag is missing in registry
+  - Production image: **rebuilt**
+  - Test image: **rebuilt**
+- **Edit `Dockerfile.base` only**
+  - Base image: **not automatically rebuilt** if `BASE_IMAGE` tag already exists
+  - Production image: **not rebuilt**
+  - Test image: **not rebuilt**
+  - Note: to force base rebuild from updated `Dockerfile.base`, also bump
+    `ARG BASE_IMAGE=...` in `Dockerfile` to a new date/tag.
+  - Caveat: if build cache is unavailable for unrelated reasons, CircleCI may
+    still rebuild production/test images.
+- **Edit `pixi.lock` only**
+  - Base image: **not rebuilt** unless `BASE_IMAGE` tag is missing
+  - Production image: **rebuilt**
+  - Test image: **rebuilt**
+- **Edit none of `Dockerfile` or `pixi.lock`**
+  - If cache/marker is restored: production/test builds are skipped by default
+  - Base image still goes through existence check and rebuilds only if missing
+
+Practical implication: if your goal is to rebuild the base image, edit
+`Dockerfile` to point to a new `BASE_IMAGE` tag; editing `Dockerfile.base` alone
+is not sufficient when that tag already exists remotely.
+
+---
+
 ## Releasing a new version
 
 ### 1. Prepare the release branch
@@ -155,7 +258,7 @@ a Linux machine** because the project only targets `linux-64`.
 
 - The main Docker image is built **FROM** `pennlinc/aslprep-base:<YYYYMMDD>` (see `Dockerfile`). The tag is a date stamp (e.g. `20260219`) indicating when the base was last built.
 - The base image is built from **Dockerfile.base** (runtime dependencies only; no Python stack) and pushed to Docker Hub with both the date tag and `latest`.
-- **CircleCI** (job `build_and_deploy`) checks if the base image already exists in the registry. If it does, the base build is skipped. If not, it builds from `Dockerfile.base` and pushes it. This means the base is only rebuilt when you bump the date tag.
+- **CircleCI** (job `image_prep`) checks if the base image already exists in the registry. If it does, the base build is skipped. If not, it builds from `Dockerfile.base` and pushes it. This means the base is only rebuilt when you bump the date tag.
 - To release a new base image:
   1. Update the date tag in **Dockerfile** (`ARG BASE_IMAGE=pennlinc/aslprep-base:YYYYMMDD`).
   2. Commit and push. The next CI run will detect the missing image and build/push it.
@@ -180,7 +283,7 @@ a Linux machine** because the project only targets `linux-64`.
   git push origin 0.7.6
   ```
 
-- Pushing the tag will trigger **CircleCI** `build_and_deploy`: build base image if missing, build main image (`pennlinc/aslprep`), and push to Docker Hub when `DOCKERHUB_TOKEN` is set. Tags pushed: `unstable` (always), `latest` and `<version>` (when `CIRCLE_TAG` is set).
+- Pushing the tag will trigger **CircleCI** image/deploy jobs: build base image if missing, build main image (`pennlinc/aslprep`), and push to Docker Hub when `DOCKERHUB_TOKEN` is set. Tags pushed: `unstable` (always), `latest` and `<version>` (when `CIRCLE_TAG` is set).
 
 ### 7. Create the GitHub Release
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,9 @@ The config module is the single source of truth for runtime parameters. Never pa
 ### Docker
 
 - Each app has a base image with runtime dependencies and a main Dockerfile that installs the Python environment and the app itself.
-- ASLPrep and fMRIPrep have migrated to **Pixi**-based multi-stage Docker builds (base has no Python; Pixi installs conda + PyPI deps from `pixi.lock`). The other repos still use micromamba + `pip install`.
-- Base image naming: ASLPrep uses `pennlinc/aslprep-base:<YYYYMMDD>` (date-based); other repos use `pennlinc/<pkg>_build:<version>`.
+- ASLPrep, fMRIPrep, and XCP-D have migrated to **Pixi**-based multi-stage Docker builds: `Dockerfile.base` owns non-Python/non-conda runtime dependencies, while `Dockerfile` uses pixi to create `build`, `test`, and production targets from `pixi.lock`. qsiprep and qsirecon still use micromamba + `pip install`.
+- Base image naming: ASLPrep and XCP-D use date-based tags (`pennlinc/<pkg>-base:<YYYYMMDD>`); qsiprep and qsirecon use `pennlinc/<pkg>_build:<version>`.
+- Entrypoint is the CLI binary in the pixi environment (e.g., `/app/.pixi/envs/<env>/bin/<pkg>`).
 - Labels follow the `org.label-schema` convention.
 
 ### Release Process
@@ -140,9 +141,9 @@ ASLPrep is a BIDS App for preprocessing Arterial Spin Labeling (ASL) perfusion M
 | Default branch | `main` |
 | Entry point | `aslprep.cli.run:main` |
 | Python requirement | `>=3.10` |
-| Build backend | hatchling + hatch-vcs |
+| Build backend | hatchling + hatch-vcs + nipreps-versions |
 | Linter | ruff ~= 0.15.0 |
-| Pre-commit | Yes (ruff v0.6.2) |
+| Pre-commit | Yes (ruff v0.15.0) |
 | Tox | Yes |
 | Docker base | `pennlinc/aslprep-base:<YYYYMMDD>` |
 | Dockerfile | Multi-stage pixi build |
@@ -190,6 +191,22 @@ ASLPrep names its test dependencies `tests` (plural) in `pyproject.toml`, consis
 
 ASLPrep's tox config references `python scripts/fetch_templates.py` as a `commands_pre` step before tests. This script downloads the required TemplateFlow templates and is also used by the Docker build's `templates` stage.
 
+### CI Trigger Conditions
+
+ASLPrep now follows the same CI trigger-condition pattern as XCP-D:
+
+- **GitHub lockfile workflow** (`.github/workflows/pixi-lock.yml`):
+  - Trigger: every `pull_request_target` event.
+  - Always runs checkout + "latest commit touched dependency files?" check.
+  - Lockfile update steps run only when latest commit touched `pyproject.toml` or `pixi.lock`.
+  - Lockfile push-back is restricted to same-repo PR branches; fork PRs do not push.
+
+- **CircleCI image workflow** (`.circleci/config.yml`):
+  - Image rebuild trigger uses cache marker restoration keyed by `Dockerfile` + `pixi.lock` checksums (`build-v3-...`).
+  - Editing `Dockerfile` or `pixi.lock` invalidates cache marker and triggers production/test image rebuild.
+  - Base image rebuild remains controlled by `BASE_IMAGE` manifest existence; `Dockerfile.base` edits alone do not force rebuild when tag exists.
+  - Branch/tag filters are workflow-level (not file-path filters): `image_prep` on all branches/tags, deploy only on `main` and tags.
+
 ### Linting Notes
 
 ASLPrep has 4 suppressed ruff rules:
@@ -226,14 +243,14 @@ This roadmap covers harmonization work across all four PennLINC BIDS Apps (qsipr
 
 6. **Rename qsiprep default branch** from `master` to `main` and update `.github/workflows/lint.yml`.
 7. ~~**Rename aslprep test extras** from `test` to `tests`~~ -- **Done**.
-8. **Converge on version management** -- recommend the simpler `_version.py` direct-import pattern (used by qsiprep/qsirecon). Migrate xcp_d and aslprep away from `__about__.py`.
+8. **Converge on version management** -- recommend the simpler `_version.py` direct-import pattern (used by qsiprep/qsirecon). ASLPrep has completed this migration; only xcp_d still uses `__about__.py`.
 9. **Pin the same ruff version** in all four repos' dev dependencies and `.pre-commit-config.yaml`.
 10. **Harmonize ruff ignore lists** -- adopt xcp_d's minimal set (`S105`, `S311`, `S603`) as the target; fix suppressed rules in qsiprep and aslprep incrementally.
 
 ### Phase 3: Shared infrastructure
 
 11. **Extract a reusable GitHub Actions workflow** for lint + codespell + build checks, hosted in a shared repo (e.g., `PennLINC/.github`).
-12. **Standardize Dockerfile patterns** -- ASLPrep and fMRIPrep have migrated to Pixi-based multi-stage builds. Migrate qsiprep, qsirecon, and xcp_d to the same pattern.
+12. **Standardize Dockerfile patterns** -- ASLPrep, fMRIPrep, and XCP-D have adopted pixi-based multi-stage Docker builds. Migrate qsiprep and qsirecon to the same pattern.
 13. **Create a shared `pennlinc-style` package or cookiecutter template** providing `pyproject.toml` lint/test config, `.pre-commit-config.yaml`, `tox.ini`, and CI workflows.
 14. **Evaluate `nipreps-versions` calver** -- the `raw-options = { version_scheme = "nipreps-calver" }` line is commented out in all four repos. Decide whether to adopt it.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ RUN pixi config set --global run-post-link-scripts insecure
 RUN mkdir /app
 COPY pixi.lock pyproject.toml /app
 WORKDIR /app
+# First install runs before COPY . so .git is missing.
+# Use --skip aslprep (lockfile name) so pixi skips building the local package.
 RUN --mount=type=cache,target=/root/.cache/rattler pixi install -e aslprep -e test --frozen --skip aslprep
 RUN --mount=type=cache,target=/root/.npm pixi run --as-is -e aslprep npm install -g svgo@^3.2.0 bids-validator@1.14.10
 RUN pixi shell-hook -e aslprep --as-is | grep -v PATH > /shell-hook.sh
@@ -58,7 +60,10 @@ RUN pixi shell-hook -e test --as-is | grep -v PATH > /test-shell-hook.sh
 
 # Finally, install the package
 COPY . /app
-RUN --mount=type=cache,target=/root/.cache/rattler pixi install -e aslprep -e test --frozen
+# Install test and production environments separately so production does not
+# inherit editable-install behavior needed for test workflows.
+RUN --mount=type=cache,target=/root/.cache/rattler pixi install -e test --frozen
+RUN --mount=type=cache,target=/root/.cache/rattler pixi install -e aslprep --frozen
 
 #
 # Pre-fetch templates


### PR DESCRIPTION
Related to https://github.com/PennLINC/xcp_d/pull/1596 and https://github.com/PennLINC/xcp_d/pull/1597.

## Changes proposed in this pull request

- Only build base image when the tag in Dockerfile is not already present on DockerHub.
- Only build production image when pixi.lock or Dockerfile are updated.
- Update maintenance documentation.