### PR TITLE
Allow non-atlas datasets in collect_atlases

### DIFF
--- a/.github/workflows/pixi-lock.yml
+++ b/.github/workflows/pixi-lock.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Install the latest version of uv
         if: ${{ steps.latest-commit.outputs.run_lockfile_update == 'true' }}
         uses: astral-sh/setup-uv@v7
+      # Lock all environments (default, test, aslprep). The aslprep env must use the
+      # non-editable workspace package variant (production feature) so the Docker
+      # runtime image can copy only the env; the Dockerfile forces a non-editable
+      # install if the lockfile resolves aslprep to the editable variant.
       - name: Update lockfile
         if: ${{ steps.latest-commit.outputs.run_lockfile_update == 'true' }}
         run: >

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
                     ca-certificates \
                     build-essential \
+                    curl \
                     git && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN pixi config set --global run-post-link-scripts insecure
@@ -64,6 +65,11 @@ COPY . /app
 # inherit editable-install behavior needed for test workflows.
 RUN --mount=type=cache,target=/root/.cache/rattler pixi install -e test --frozen
 RUN --mount=type=cache,target=/root/.cache/rattler pixi install -e aslprep --frozen
+# Ensure aslprep is installed non-editably in the aslprep env so the copied env is
+# self-contained in the runtime image (lockfile may resolve to editable variant).
+# Pixi envs do not include pip; use uv to install into the env's Python.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    /root/.local/bin/uv pip install --python /app/.pixi/envs/aslprep/bin/python --no-deps --force-reinstall .
 
 #
 # Pre-fetch templates

--- a/aslprep/data/atlas_bids_config.json
+++ b/aslprep/data/atlas_bids_config.json
@@ -10,34 +10,6 @@
             "name": "cohort",
             "pattern": "[_/\\\\]+cohort-([a-zA-Z0-9+]+)",
             "directory": "{cohort}"
-        },
-        {
-            "name": "atlas",
-            "pattern": "[_/\\\\]+atlas-([a-zA-Z0-9+]+)"
-        },
-        {
-            "name": "hemi",
-            "pattern": "[_/\\\\]+hemi-(L|R)"
-        },
-        {
-            "name": "res",
-            "pattern": "[_/\\\\]+res-([a-zA-Z0-9]+)"
-        },
-        {
-            "name": "den",
-            "pattern": "[_/\\\\]+den-([a-zA-Z0-9]+)"
-        },
-        {
-            "name": "desc",
-            "pattern": "[_/\\\\]+desc-([a-zA-Z0-9+]+)"
-        },
-        {
-            "name": "suffix",
-            "pattern": "(?:^|[_/\\\\])([a-zA-Z0-9]+)\\.[^/\\\\]+$"
-        },
-        {
-            "name": "extension",
-            "pattern": "[^./\\\\](\\.[^/\\\\]+)$"
         }
     ],
     "default_path_patterns": [

--- a/aslprep/tests/run_local_tests.py
+++ b/aslprep/tests/run_local_tests.py
@@ -67,9 +67,9 @@ def run_command(command, env=None):
 def run_tests(test_regex, test_mark):
     """Run the tests."""
     local_patch = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    mounted_code = '/opt/conda/envs/aslprep/lib/python3.12/site-packages/aslprep'
+    mounted_code = '/app/.pixi/envs/aslprep/lib/python3.12/site-packages/aslprep'
     run_str = 'docker run --rm -ti '
-    run_str += f'-v {local_patch}:/opt/conda/envs/aslprep/lib/python3.12/site-packages/aslprep '
+    run_str += f'-v {local_patch}:{mounted_code} '
     run_str += '--entrypoint pytest '
     run_str += 'pennlinc/aslprep:unstable '
     run_str += (

--- a/aslprep/utils/atlas.py
+++ b/aslprep/utils/atlas.py
@@ -110,7 +110,11 @@ def collect_atlases(datasets, atlases, bids_filters=None):
     atlas_cache = {}
     for dataset_name, dataset_path in datasets.items():
         if not isinstance(dataset_path, BIDSLayout):
-            layout = BIDSLayout(dataset_path, config=[atlas_cfg], validate=False)
+            layout = BIDSLayout(
+                dataset_path,
+                config=["bids", "derivatives", atlas_cfg],
+                validate=False,
+            )
         else:
             layout = dataset_path
 

--- a/aslprep/utils/atlas.py
+++ b/aslprep/utils/atlas.py
@@ -112,7 +112,7 @@ def collect_atlases(datasets, atlases, bids_filters=None):
         if not isinstance(dataset_path, BIDSLayout):
             layout = BIDSLayout(
                 dataset_path,
-                config=["bids", "derivatives", atlas_cfg],
+                config=['bids', 'derivatives', atlas_cfg],
                 validate=False,
             )
         else:

--- a/pixi.lock
+++ b/pixi.lock
@@ -6,6 +6,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -521,6 +523,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -1007,6 +1011,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -1687,86 +1693,11 @@ packages:
   timestamp: 1760831179410
 - pypi: ./
   name: aslprep
-  version: 26.1.0.dev3+g3875cba62
-  sha256: f76cdfecea176d259bfc7a780f01706b616fef67a182524570fcdad7ceec7f89
+  version: 26.1.0.dev3+g86311fd98.d20260313
+  sha256: e0e996eb34ce224f9fd29096ea9d7590d0b4611d5dbac9765816e36460677d09
   requires_dist:
   - acres>=0.2.0
   - fmriprep~=25.2.2
-  - importlib-resources ; python_full_version < '3.11'
-  - indexed-gzip
-  - looseversion>=1.3
-  - networkx~=3.3
-  - nibabel>=5.1.1
-  - nilearn~=0.13.0
-  - nipype>=1.9.0
-  - nireports>=25.1.0
-  - nitransforms>=25.0.1
-  - niworkflows>=1.14.4
-  - numpy~=2.2
-  - packaging>=24
-  - pandas>=2.2
-  - psutil>=5.4
-  - pybids>=0.16
-  - requests>=2.27
-  - sdcflows>=2.15.0
-  - sentry-sdk
-  - smriprep>=0.19.2
-  - tedana~=25.1.1a1
-  - templateflow>=24.2.2
-  - toml>=0.10
-  - transforms3d>=0.4.2
-  - codecov ; extra == 'all'
-  - coverage ; extra == 'all'
-  - doctest-ignore-unicode ; extra == 'all'
-  - fuzzywuzzy ; extra == 'all'
-  - lxml-html-clean ; extra == 'all'
-  - myst-parser ; extra == 'all'
-  - nbsphinx ; extra == 'all'
-  - packaging ; extra == 'all'
-  - pre-commit ; extra == 'all'
-  - pydot>=1.2.3 ; extra == 'all'
-  - pydotplus ; extra == 'all'
-  - pytest ; extra == 'all'
-  - pytest-cov ; extra == 'all'
-  - python-levenshtein ; extra == 'all'
-  - ruff~=0.15.0 ; extra == 'all'
-  - sphinx-argparse ; extra == 'all'
-  - sphinx-markdown-tables ; extra == 'all'
-  - sphinx-rtd-theme>=1.2.2 ; extra == 'all'
-  - sphinx>=6.2.1 ; extra == 'all'
-  - sphinxcontrib-apidoc ; extra == 'all'
-  - sphinxcontrib-bibtex ; extra == 'all'
-  - pre-commit ; extra == 'dev'
-  - ruff~=0.15.0 ; extra == 'dev'
-  - doctest-ignore-unicode ; extra == 'doc'
-  - lxml-html-clean ; extra == 'doc'
-  - myst-parser ; extra == 'doc'
-  - nbsphinx ; extra == 'doc'
-  - packaging ; extra == 'doc'
-  - pydot>=1.2.3 ; extra == 'doc'
-  - pydotplus ; extra == 'doc'
-  - sphinx-argparse ; extra == 'doc'
-  - sphinx-markdown-tables ; extra == 'doc'
-  - sphinx-rtd-theme>=1.2.2 ; extra == 'doc'
-  - sphinx>=6.2.1 ; extra == 'doc'
-  - sphinxcontrib-apidoc ; extra == 'doc'
-  - sphinxcontrib-bibtex ; extra == 'doc'
-  - fuzzywuzzy ; extra == 'maint'
-  - python-levenshtein ; extra == 'maint'
-  - codecov ; extra == 'tests'
-  - coverage ; extra == 'tests'
-  - pytest ; extra == 'tests'
-  - pytest-cov ; extra == 'tests'
-  requires_python: '>=3.10'
-  editable: true
-- pypi: ./
-  name: aslprep
-  version: 26.1.0.dev3+g3875cba62
-  sha256: f76cdfecea176d259bfc7a780f01706b616fef67a182524570fcdad7ceec7f89
-  requires_dist:
-  - acres>=0.2.0
-  - fmriprep~=25.2.2
-  - importlib-resources ; python_full_version < '3.11'
   - indexed-gzip
   - looseversion>=1.3
   - networkx~=3.3

--- a/pixi.lock
+++ b/pixi.lock
@@ -6,8 +6,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -523,8 +521,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -1011,8 +1007,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -1763,6 +1757,79 @@ packages:
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   requires_python: '>=3.10'
+- pypi: ./
+  name: aslprep
+  version: 26.1.0.dev4+g32aa5f5ab
+  sha256: e0e996eb34ce224f9fd29096ea9d7590d0b4611d5dbac9765816e36460677d09
+  requires_dist:
+  - acres>=0.2.0
+  - fmriprep~=25.2.2
+  - indexed-gzip
+  - looseversion>=1.3
+  - networkx~=3.3
+  - nibabel>=5.1.1
+  - nilearn~=0.13.0
+  - nipype>=1.9.0
+  - nireports>=25.1.0
+  - nitransforms>=25.0.1
+  - niworkflows>=1.14.4
+  - numpy~=2.2
+  - packaging>=24
+  - pandas>=2.2
+  - psutil>=5.4
+  - pybids>=0.16
+  - requests>=2.27
+  - sdcflows>=2.15.0
+  - sentry-sdk
+  - smriprep>=0.19.2
+  - tedana~=25.1.1a1
+  - templateflow>=24.2.2
+  - toml>=0.10
+  - transforms3d>=0.4.2
+  - codecov ; extra == 'all'
+  - coverage ; extra == 'all'
+  - doctest-ignore-unicode ; extra == 'all'
+  - fuzzywuzzy ; extra == 'all'
+  - lxml-html-clean ; extra == 'all'
+  - myst-parser ; extra == 'all'
+  - nbsphinx ; extra == 'all'
+  - packaging ; extra == 'all'
+  - pre-commit ; extra == 'all'
+  - pydot>=1.2.3 ; extra == 'all'
+  - pydotplus ; extra == 'all'
+  - pytest ; extra == 'all'
+  - pytest-cov ; extra == 'all'
+  - python-levenshtein ; extra == 'all'
+  - ruff~=0.15.0 ; extra == 'all'
+  - sphinx-argparse ; extra == 'all'
+  - sphinx-markdown-tables ; extra == 'all'
+  - sphinx-rtd-theme>=1.2.2 ; extra == 'all'
+  - sphinx>=6.2.1 ; extra == 'all'
+  - sphinxcontrib-apidoc ; extra == 'all'
+  - sphinxcontrib-bibtex ; extra == 'all'
+  - pre-commit ; extra == 'dev'
+  - ruff~=0.15.0 ; extra == 'dev'
+  - doctest-ignore-unicode ; extra == 'doc'
+  - lxml-html-clean ; extra == 'doc'
+  - myst-parser ; extra == 'doc'
+  - nbsphinx ; extra == 'doc'
+  - packaging ; extra == 'doc'
+  - pydot>=1.2.3 ; extra == 'doc'
+  - pydotplus ; extra == 'doc'
+  - sphinx-argparse ; extra == 'doc'
+  - sphinx-markdown-tables ; extra == 'doc'
+  - sphinx-rtd-theme>=1.2.2 ; extra == 'doc'
+  - sphinx>=6.2.1 ; extra == 'doc'
+  - sphinxcontrib-apidoc ; extra == 'doc'
+  - sphinxcontrib-bibtex ; extra == 'doc'
+  - fuzzywuzzy ; extra == 'maint'
+  - python-levenshtein ; extra == 'maint'
+  - codecov ; extra == 'tests'
+  - coverage ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  requires_python: '>=3.10'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
   sha256: ee4da0f3fe9d59439798ee399ef3e482791e48784873d546e706d0935f9ff010
   md5: 9673a61a297b00016442e022d689faa6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,11 @@ classifiers = [
 license = {file = "LICENSE.md"}
 requires-python = ">=3.10"
 dependencies = [
-    'importlib_resources; python_version < "3.11"',
     "acres >= 0.2.0",
     "fmriprep ~= 25.2.2",
     "indexed_gzip",
     "looseversion >= 1.3",
-    "networkx ~= 3.3",  # nipype needs networkx, but 3+ isn"t compatible with nipype 1.8.5
+    "networkx ~= 3.3",
     "nibabel >= 5.1.1",
     "nilearn ~= 0.13.0",
     "nipype >= 1.9.0",


### PR DESCRIPTION
Closes #631.

## Changes proposed in this pull request

- Use combination of "bids", "derivatives", and custom atlas config for BIDSLayouts in `collect_atlases`. I had just been using a custom atlas config with all of the entities allowed for atlases, but this broke BIDSLayout initialization with non-atlas datasets (e.g., when passing in fMRIPrep derivatives to use in the workflow).
- Fix mount point for local testing.
- Remove unused python < 3.11 limit in pyproject.toml. 3.12 was being installed regardless.
- Copy over Dockerfile fix from https://github.com/PennLINC/xcp_d/pull/1604.