### PR TITLE
Use continuous TPM-based procedure to calculate aCompCor masks

### DIFF
--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -447,7 +447,7 @@ configured with *Lanczos* interpolation to minimize the smoothing effects of oth
     asl_confounds_wf = init_asl_confounds_wf(
         n_volumes=n_vols,
         mem_gb=mem_gb['largemem'],
-        freesurfer=config.workflow.run_reconall,
+        freesurfer=False,  # sMRIPrep always uses FAST for TPMs
         name='asl_confounds_wf',
     )
 

--- a/aslprep/workflows/asl/confounds.py
+++ b/aslprep/workflows/asl/confounds.py
@@ -49,7 +49,7 @@ def init_asl_confounds_wf(
                 wf = init_asl_confounds_wf(
                     n_volumes=50,
                     mem_gb=1,
-                    freesurfer=True,
+                    freesurfer=False,
                 )
 
     Parameters
@@ -63,7 +63,9 @@ def init_asl_confounds_wf(
         should be calculated after resamplings that may extend
         the FoV
     freesurfer : :obj:`bool`
-        True if FreeSurfer derivatives were used.
+        Set to ``True`` if the input volume fractions for the anatomical
+        component-based noise correction maps come from FreeSurfer's ``aseg``.
+        sMRIPrep always uses FAST for tissue probability maps, so we always set this to False.
     name : :obj:`str`
         Name of workflow (default: ``asl_confounds_wf``)
 


### PR DESCRIPTION
Reproduce https://github.com/nipreps/fmriprep/pull/3589.

## Changes proposed in this pull request

- Assume that anatomical TPMs come from FAST and not Freesurfer's aseg output, since sMRIPrep always uses FAST. This means setting freesurfer to False in init_asl_confs_wf.