### PR TITLE
FIX: guard against divide-by-zero in dispersion_index

### DIFF
--- a/aslprep/tests/test_utils_confounds.py
+++ b/aslprep/tests/test_utils_confounds.py
@@ -1,0 +1,72 @@
+"""Tests for the aslprep.utils.confounds module."""
+
+import numpy as np
+import pytest
+
+from aslprep.utils.confounds import dispersion_index
+
+
+def _make_masks(shape, gm_n=2, wm_n=2, csf_n=2):
+    """Create simple non-overlapping boolean masks with the requested voxel counts."""
+    gm_mask = np.zeros(shape, dtype=bool)
+    wm_mask = np.zeros(shape, dtype=bool)
+    csf_mask = np.zeros(shape, dtype=bool)
+
+    flat_gm = gm_mask.ravel()
+    flat_wm = wm_mask.ravel()
+    flat_csf = csf_mask.ravel()
+
+    flat_gm[:gm_n] = True
+    flat_wm[gm_n : gm_n + wm_n] = True
+    flat_csf[gm_n + wm_n : gm_n + wm_n + csf_n] = True
+
+    return (
+        gm_mask.reshape(shape),
+        wm_mask.reshape(shape),
+        csf_mask.reshape(shape),
+    )
+
+
+def test_dispersion_index_normal():
+    """dispersion_index returns a finite, non-negative float for valid inputs."""
+    rng = np.random.default_rng(0)
+    shape = (5, 5, 5)
+    cbf_image = rng.random(shape).astype(np.float32) + 0.1  # ensure positive, non-zero values
+
+    gm_mask, wm_mask, csf_mask = _make_masks(shape)
+
+    result = dispersion_index(wm_mask, gm_mask, csf_mask, cbf_image)
+    assert np.isfinite(result)
+    assert result >= 0
+
+
+@pytest.mark.parametrize(
+    ('desc', 'gm_n', 'wm_n', 'csf_n', 'match'),
+    [
+        ('GM has 1 voxel', 1, 2, 2, 'GM mask contains 1 voxel'),
+        ('WM has 1 voxel', 2, 1, 2, 'WM mask contains 1 voxel'),
+        ('CSF has 1 voxel', 2, 2, 1, 'CSF mask contains 1 voxel'),
+        ('GM has 0 voxels', 0, 2, 2, 'GM mask contains 0 voxel'),
+    ],
+)
+def test_dispersion_index_insufficient_tissue_voxels(desc, gm_n, wm_n, csf_n, match):
+    """dispersion_index raises ValueError when any tissue mask has fewer than 2 voxels."""
+    rng = np.random.default_rng(0)
+    shape = (5, 5, 5)
+    cbf_image = rng.random(shape).astype(np.float32)
+
+    gm_mask, wm_mask, csf_mask = _make_masks(shape, gm_n=gm_n, wm_n=wm_n, csf_n=csf_n)
+
+    with pytest.raises(ValueError, match=match):
+        dispersion_index(wm_mask, gm_mask, csf_mask, cbf_image)
+
+
+def test_dispersion_index_zero_mean_gm_cbf():
+    """dispersion_index raises ValueError when mean GM CBF is zero."""
+    shape = (5, 5, 5)
+    cbf_image = np.zeros(shape, dtype=np.float32)
+
+    gm_mask, wm_mask, csf_mask = _make_masks(shape)
+
+    with pytest.raises(ValueError, match='Mean GM CBF is zero'):
+        dispersion_index(wm_mask, gm_mask, csf_mask, cbf_image)

--- a/aslprep/utils/confounds.py
+++ b/aslprep/utils/confounds.py
@@ -298,7 +298,13 @@ def dispersion_index(wm_mask, gm_mask, csf_mask, cbf_image):
     n_gm = np.sum(gm_mask)
     n_wm = np.sum(wm_mask)
     n_csf = np.sum(csf_mask)
-    # TODO: possibly add a check to ensure that n_gm, n_wm, n_csf are all greater than 1
+
+    for tissue, count in (('GM', n_gm), ('WM', n_wm), ('CSF', n_csf)):
+        if count < 2:
+            raise ValueError(
+                f'{tissue} mask contains {count} voxel(s), but at least 2 are required '
+                'to compute the dispersion index.'
+            )
 
     V = (
         (n_gm - 1) * np.var(cbf_data[gm_mask])
@@ -307,6 +313,9 @@ def dispersion_index(wm_mask, gm_mask, csf_mask, cbf_image):
     ) / (n_gm + n_wm + n_csf - 3)
 
     mean_gm_cbf = np.mean(cbf_data[gm_mask])
+    if mean_gm_cbf == 0:
+        raise ValueError('Mean GM CBF is zero; cannot compute the dispersion index.')
+
     return V / np.abs(mean_gm_cbf)
 
 


### PR DESCRIPTION
## Changes proposed in this pull request

Fixes a potential divide-by-zero bug in `dispersion_index` (`aslprep/utils/confounds.py`).

Two failure modes:

1. **Degenerate tissue masks** — if any of the GM, WM, or CSF binary masks contained fewer than 2 voxels, `np.var()` on an empty array would silently return `nan`, and the pooled-variance denominator `(n_gm + n_wm + n_csf - 3)` could reach zero (e.g. exactly 1 voxel per mask → `1 + 1 + 1 - 3 = 0`), producing a silent `ZeroDivisionError` or `nan` result with no indication of what went wrong.

2. **Zero mean GM CBF** — if the mean CBF across the GM mask was exactly zero, the final `V / np.abs(mean_gm_cbf)` return would silently produce `inf`.

This PR resolves the TODO left in the original code ([line 301](https://github.com/PennLINC/aslprep/blob/main/aslprep/utils/confounds.py#L301)) by adding explicit pre-flight `ValueError` checks before either computation is attempted. The error messages name the specific tissue that failed, which makes debugging in QC pipelines straightforward.

I found the comment as a TODO in the code, so haven't opened a new issue for this.

No changes to the public API or existing behaviour for valid inputs.

## Documentation that should be reviewed

No documentation changes required. The fix is internal to the function and the docstring contract (returns a `float`) is unchanged for valid inputs.