### PR TITLE
Add QC metrics for percentage of voxels exceeding thresholds

### DIFF
--- a/aslprep/interfaces/confounds.py
+++ b/aslprep/interfaces/confounds.py
@@ -286,7 +286,7 @@ class ComputeCBFQC(SimpleInterface):
             qei_cbf_scrub_di = np.nan
             percentage_negative_cbf_scrub = np.nan
 
-            
+
             cbf_score_thresh_stats = {
                 f'perc_voxels_cbf_gt_{t}': np.nan for t in CBF_THRESH_DEFAULTS
             }

--- a/aslprep/interfaces/confounds.py
+++ b/aslprep/interfaces/confounds.py
@@ -19,8 +19,10 @@ from nipype.utils.filemanip import fname_presuffix
 from nipype.utils.misc import normalize_mc_params
 
 from aslprep.utils.confounds import (
+    CBF_THRESH_DEFAULTS,
     _gather_confounds,
     average_cbf_by_tissue,
+    compute_cbf_threshold_stats,
     compute_qei,
     dice,
     overlap,
@@ -231,6 +233,12 @@ class ComputeCBFQC(SimpleInterface):
             thresh=thresh,
         )
 
+        # mean cbf thresh stats
+        cbf_thresh_stats = compute_cbf_threshold_stats(
+            cbf=self.inputs.mean_cbf,
+            mask=self.inputs.asl_mask,
+        )
+
         if self.inputs.mean_cbf_score:
             (
                 qei_cbf_score,
@@ -256,6 +264,17 @@ class ComputeCBFQC(SimpleInterface):
                 img=self.inputs.mean_cbf_scrub,
                 thresh=thresh,
             )
+
+            # cbf SCORE thresh stats
+            cbf_score_thresh_stats = compute_cbf_threshold_stats(
+                cbf=self.inputs.mean_cbf_score,
+                mask=self.inputs.asl_mask,
+            )
+            # cbf SCRUB thresh stats
+            cbf_scrub_thresh_stats = compute_cbf_threshold_stats(
+                cbf=self.inputs.mean_cbf_scrub,
+                mask=self.inputs.asl_mask,
+            )
         else:
             print('no score inputs, setting to np.nan')
             qei_cbf_score = np.nan
@@ -266,6 +285,14 @@ class ComputeCBFQC(SimpleInterface):
             qei_cbf_scrub_rho_ss = np.nan
             qei_cbf_scrub_di = np.nan
             percentage_negative_cbf_scrub = np.nan
+
+            
+            cbf_score_thresh_stats = {
+                f'perc_voxels_cbf_gt_{t}': np.nan for t in CBF_THRESH_DEFAULTS
+            }
+            cbf_scrub_thresh_stats = {
+                f'perc_voxels_cbf_gt_{t}': np.nan for t in CBF_THRESH_DEFAULTS
+            }
 
         if self.inputs.mean_cbf_basil:
             (
@@ -292,6 +319,14 @@ class ComputeCBFQC(SimpleInterface):
                 img=self.inputs.mean_cbf_gm_basil,
                 thresh=thresh,
             )
+            cbf_basil_thresh_stats = compute_cbf_threshold_stats(
+                cbf=self.inputs.mean_cbf_basil,
+                mask=self.inputs.asl_mask,
+            )
+            cbf_basil_gm_thresh_stats = compute_cbf_threshold_stats(
+                cbf=self.inputs.mean_cbf_gm_basil,
+                mask=self.inputs.asl_mask,
+            )
         else:
             print('no basil inputs, setting to np.nan')
             qei_cbf_basil = np.nan
@@ -302,6 +337,14 @@ class ComputeCBFQC(SimpleInterface):
             qei_cbf_basil_gm_di = np.nan
             percentage_negative_cbf_basil = np.nan
             percentage_negative_cbf_basil_gm = np.nan
+
+            # cbf threshold stats (BASIL)
+            cbf_basil_thresh_stats = {
+                f'perc_voxels_cbf_gt_{t}': np.nan for t in CBF_THRESH_DEFAULTS
+            }
+            cbf_basil_gm_thresh_stats = {
+                f'perc_voxels_cbf_gt_{t}': np.nan for t in CBF_THRESH_DEFAULTS
+            }
 
         ratio_gm_wm_cbf = np.divide(mean_cbf_mean[0], mean_cbf_mean[1])
 
@@ -342,6 +385,32 @@ class ComputeCBFQC(SimpleInterface):
             'mean_gm_cbf': [mean_cbf_mean[0]],
             'mean_wm_cbf': [mean_cbf_mean[1]],
             'ratio_gm_wm_cbf': [ratio_gm_wm_cbf],
+
+
+
+            # cbf threshold stats (mean CBF)
+
+            **{k: [v] for k, v in cbf_thresh_stats.items()},
+            # cbf threshold stats (SCORE)
+            **{
+                k.replace('_cbf_', '_cbf_score_'): [v]
+                for k, v in cbf_score_thresh_stats.items()
+            },
+            # cbf threshold stats (SCRUB)
+            **{
+                k.replace('_cbf_', '_cbf_scrub_'): [v]
+                for k, v in cbf_scrub_thresh_stats.items()
+            },
+            # cbf threshold stats (BASIL)
+            **{
+                k.replace('_cbf_', '_cbf_basil_'): [v]
+                for k, v in cbf_basil_thresh_stats.items()
+            },
+            # cbf threshold stats (BASIL GM-PVC)
+            **{
+                k.replace('_cbf_', '_cbf_basil_gm_'): [v]
+                for k, v in cbf_basil_gm_thresh_stats.items()
+            },
         }
 
         qc_metadata = {
@@ -546,6 +615,178 @@ class ComputeCBFQC(SimpleInterface):
                 'Description': (
                     'The ratio between the mean gray matter and mean white matter CBF values.'
                 ),
+            },
+
+
+            # cbf threshold stats (mean CBF)
+            'perc_voxels_cbf_gt_100': {
+                'LongName': (
+                    'Percentage of Voxels with CBF Greater Than 100 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with mean CBF strictly greater than '
+                    '100 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            'perc_voxels_cbf_gt_150': {
+                'LongName': (
+                    'Percentage of Voxels with CBF Greater Than 150 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with mean CBF strictly greater than '
+                    '150 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            'perc_voxels_cbf_gt_200': {
+                'LongName': (
+                    'Percentage of Voxels with CBF Greater Than 200 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with mean CBF strictly greater than '
+                    '200 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            # cbf threshold stats (SCORE)
+            'perc_voxels_cbf_score_gt_100': {
+                'LongName': (
+                    'Percentage of Voxels with SCORE-Denoised CBF Greater Than '
+                    '100 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with SCORE-denoised CBF strictly '
+                    'greater than 100 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            'perc_voxels_cbf_score_gt_150': {
+                'LongName': (
+                    'Percentage of Voxels with SCORE-Denoised CBF Greater Than '
+                    '150 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with SCORE-denoised CBF strictly '
+                    'greater than 150 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            'perc_voxels_cbf_score_gt_200': {
+                'LongName': (
+                    'Percentage of Voxels with SCORE-Denoised CBF Greater Than '
+                    '200 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with SCORE-denoised CBF strictly '
+                    'greater than 200 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            # cbf threshold stats (SCRUB)
+            'perc_voxels_cbf_scrub_gt_100': {
+                'LongName': (
+                    'Percentage of Voxels with SCRUB-Denoised CBF Greater Than '
+                    '100 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with SCRUB-denoised CBF strictly '
+                    'greater than 100 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            'perc_voxels_cbf_scrub_gt_150': {
+                'LongName': (
+                    'Percentage of Voxels with SCRUB-Denoised CBF Greater Than '
+                    '150 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with SCRUB-denoised CBF strictly '
+                    'greater than 150 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            'perc_voxels_cbf_scrub_gt_200': {
+                'LongName': (
+                    'Percentage of Voxels with SCRUB-Denoised CBF Greater Than '
+                    '200 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with SCRUB-denoised CBF strictly '
+                    'greater than 200 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            # cbf threshold stats (BASIL)
+            'perc_voxels_cbf_basil_gt_100': {
+                'LongName': (
+                    'Percentage of Voxels with BASIL CBF Greater Than '
+                    '100 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with BASIL CBF strictly '
+                    'greater than 100 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            'perc_voxels_cbf_basil_gt_150': {
+                'LongName': (
+                    'Percentage of Voxels with BASIL CBF Greater Than '
+                    '150 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with BASIL CBF strictly '
+                    'greater than 150 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            'perc_voxels_cbf_basil_gt_200': {
+                'LongName': (
+                    'Percentage of Voxels with BASIL CBF Greater Than '
+                    '200 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with BASIL CBF strictly '
+                    'greater than 200 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            # cbf threshold stats (BASIL GM-PVC)
+            'perc_voxels_cbf_basil_gm_gt_100': {
+                'LongName': (
+                    'Percentage of Voxels with BASIL Gray Matter Partial Volume '
+                    'Corrected CBF Greater Than 100 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with gray matter partial '
+                    'volume-corrected BASIL CBF strictly greater than '
+                    '100 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            'perc_voxels_cbf_basil_gm_gt_150': {
+                'LongName': (
+                    'Percentage of Voxels with BASIL Gray Matter Partial Volume '
+                    'Corrected CBF Greater Than 150 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with gray matter partial '
+                    'volume-corrected BASIL CBF strictly greater than '
+                    '150 mL/100 g/min.'
+                ),
+                'Units': 'percent',
+            },
+            'perc_voxels_cbf_basil_gm_gt_200': {
+                'LongName': (
+                    'Percentage of Voxels with BASIL Gray Matter Partial Volume '
+                    'Corrected CBF Greater Than 200 mL/100 g/min'
+                ),
+                'Description': (
+                    'Percentage of in-mask voxels with gray matter partial '
+                    'volume-corrected BASIL CBF strictly greater than '
+                    '200 mL/100 g/min.'
+                ),
+                'Units': 'percent',
             },
         }
 

--- a/aslprep/interfaces/confounds.py
+++ b/aslprep/interfaces/confounds.py
@@ -286,7 +286,6 @@ class ComputeCBFQC(SimpleInterface):
             qei_cbf_scrub_di = np.nan
             percentage_negative_cbf_scrub = np.nan
 
-
             cbf_score_thresh_stats = {
                 f'perc_voxels_cbf_gt_{t}': np.nan for t in CBF_THRESH_DEFAULTS
             }
@@ -385,27 +384,14 @@ class ComputeCBFQC(SimpleInterface):
             'mean_gm_cbf': [mean_cbf_mean[0]],
             'mean_wm_cbf': [mean_cbf_mean[1]],
             'ratio_gm_wm_cbf': [ratio_gm_wm_cbf],
-
-
-
             # cbf threshold stats (mean CBF)
-
             **{k: [v] for k, v in cbf_thresh_stats.items()},
             # cbf threshold stats (SCORE)
-            **{
-                k.replace('_cbf_', '_cbf_score_'): [v]
-                for k, v in cbf_score_thresh_stats.items()
-            },
+            **{k.replace('_cbf_', '_cbf_score_'): [v] for k, v in cbf_score_thresh_stats.items()},
             # cbf threshold stats (SCRUB)
-            **{
-                k.replace('_cbf_', '_cbf_scrub_'): [v]
-                for k, v in cbf_scrub_thresh_stats.items()
-            },
+            **{k.replace('_cbf_', '_cbf_scrub_'): [v] for k, v in cbf_scrub_thresh_stats.items()},
             # cbf threshold stats (BASIL)
-            **{
-                k.replace('_cbf_', '_cbf_basil_'): [v]
-                for k, v in cbf_basil_thresh_stats.items()
-            },
+            **{k.replace('_cbf_', '_cbf_basil_'): [v] for k, v in cbf_basil_thresh_stats.items()},
             # cbf threshold stats (BASIL GM-PVC)
             **{
                 k.replace('_cbf_', '_cbf_basil_gm_'): [v]
@@ -616,13 +602,9 @@ class ComputeCBFQC(SimpleInterface):
                     'The ratio between the mean gray matter and mean white matter CBF values.'
                 ),
             },
-
-
             # cbf threshold stats (mean CBF)
             'perc_voxels_cbf_gt_100': {
-                'LongName': (
-                    'Percentage of Voxels with CBF Greater Than 100 mL/100 g/min'
-                ),
+                'LongName': ('Percentage of Voxels with CBF Greater Than 100 mL/100 g/min'),
                 'Description': (
                     'Percentage of in-mask voxels with mean CBF strictly greater than '
                     '100 mL/100 g/min.'
@@ -630,9 +612,7 @@ class ComputeCBFQC(SimpleInterface):
                 'Units': 'percent',
             },
             'perc_voxels_cbf_gt_150': {
-                'LongName': (
-                    'Percentage of Voxels with CBF Greater Than 150 mL/100 g/min'
-                ),
+                'LongName': ('Percentage of Voxels with CBF Greater Than 150 mL/100 g/min'),
                 'Description': (
                     'Percentage of in-mask voxels with mean CBF strictly greater than '
                     '150 mL/100 g/min.'
@@ -640,9 +620,7 @@ class ComputeCBFQC(SimpleInterface):
                 'Units': 'percent',
             },
             'perc_voxels_cbf_gt_200': {
-                'LongName': (
-                    'Percentage of Voxels with CBF Greater Than 200 mL/100 g/min'
-                ),
+                'LongName': ('Percentage of Voxels with CBF Greater Than 200 mL/100 g/min'),
                 'Description': (
                     'Percentage of in-mask voxels with mean CBF strictly greater than '
                     '200 mL/100 g/min.'
@@ -652,8 +630,7 @@ class ComputeCBFQC(SimpleInterface):
             # cbf threshold stats (SCORE)
             'perc_voxels_cbf_score_gt_100': {
                 'LongName': (
-                    'Percentage of Voxels with SCORE-Denoised CBF Greater Than '
-                    '100 mL/100 g/min'
+                    'Percentage of Voxels with SCORE-Denoised CBF Greater Than 100 mL/100 g/min'
                 ),
                 'Description': (
                     'Percentage of in-mask voxels with SCORE-denoised CBF strictly '
@@ -663,8 +640,7 @@ class ComputeCBFQC(SimpleInterface):
             },
             'perc_voxels_cbf_score_gt_150': {
                 'LongName': (
-                    'Percentage of Voxels with SCORE-Denoised CBF Greater Than '
-                    '150 mL/100 g/min'
+                    'Percentage of Voxels with SCORE-Denoised CBF Greater Than 150 mL/100 g/min'
                 ),
                 'Description': (
                     'Percentage of in-mask voxels with SCORE-denoised CBF strictly '
@@ -674,8 +650,7 @@ class ComputeCBFQC(SimpleInterface):
             },
             'perc_voxels_cbf_score_gt_200': {
                 'LongName': (
-                    'Percentage of Voxels with SCORE-Denoised CBF Greater Than '
-                    '200 mL/100 g/min'
+                    'Percentage of Voxels with SCORE-Denoised CBF Greater Than 200 mL/100 g/min'
                 ),
                 'Description': (
                     'Percentage of in-mask voxels with SCORE-denoised CBF strictly '
@@ -686,8 +661,7 @@ class ComputeCBFQC(SimpleInterface):
             # cbf threshold stats (SCRUB)
             'perc_voxels_cbf_scrub_gt_100': {
                 'LongName': (
-                    'Percentage of Voxels with SCRUB-Denoised CBF Greater Than '
-                    '100 mL/100 g/min'
+                    'Percentage of Voxels with SCRUB-Denoised CBF Greater Than 100 mL/100 g/min'
                 ),
                 'Description': (
                     'Percentage of in-mask voxels with SCRUB-denoised CBF strictly '
@@ -697,8 +671,7 @@ class ComputeCBFQC(SimpleInterface):
             },
             'perc_voxels_cbf_scrub_gt_150': {
                 'LongName': (
-                    'Percentage of Voxels with SCRUB-Denoised CBF Greater Than '
-                    '150 mL/100 g/min'
+                    'Percentage of Voxels with SCRUB-Denoised CBF Greater Than 150 mL/100 g/min'
                 ),
                 'Description': (
                     'Percentage of in-mask voxels with SCRUB-denoised CBF strictly '
@@ -708,8 +681,7 @@ class ComputeCBFQC(SimpleInterface):
             },
             'perc_voxels_cbf_scrub_gt_200': {
                 'LongName': (
-                    'Percentage of Voxels with SCRUB-Denoised CBF Greater Than '
-                    '200 mL/100 g/min'
+                    'Percentage of Voxels with SCRUB-Denoised CBF Greater Than 200 mL/100 g/min'
                 ),
                 'Description': (
                     'Percentage of in-mask voxels with SCRUB-denoised CBF strictly '
@@ -719,10 +691,7 @@ class ComputeCBFQC(SimpleInterface):
             },
             # cbf threshold stats (BASIL)
             'perc_voxels_cbf_basil_gt_100': {
-                'LongName': (
-                    'Percentage of Voxels with BASIL CBF Greater Than '
-                    '100 mL/100 g/min'
-                ),
+                'LongName': ('Percentage of Voxels with BASIL CBF Greater Than 100 mL/100 g/min'),
                 'Description': (
                     'Percentage of in-mask voxels with BASIL CBF strictly '
                     'greater than 100 mL/100 g/min.'
@@ -730,10 +699,7 @@ class ComputeCBFQC(SimpleInterface):
                 'Units': 'percent',
             },
             'perc_voxels_cbf_basil_gt_150': {
-                'LongName': (
-                    'Percentage of Voxels with BASIL CBF Greater Than '
-                    '150 mL/100 g/min'
-                ),
+                'LongName': ('Percentage of Voxels with BASIL CBF Greater Than 150 mL/100 g/min'),
                 'Description': (
                     'Percentage of in-mask voxels with BASIL CBF strictly '
                     'greater than 150 mL/100 g/min.'
@@ -741,10 +707,7 @@ class ComputeCBFQC(SimpleInterface):
                 'Units': 'percent',
             },
             'perc_voxels_cbf_basil_gt_200': {
-                'LongName': (
-                    'Percentage of Voxels with BASIL CBF Greater Than '
-                    '200 mL/100 g/min'
-                ),
+                'LongName': ('Percentage of Voxels with BASIL CBF Greater Than 200 mL/100 g/min'),
                 'Description': (
                     'Percentage of in-mask voxels with BASIL CBF strictly '
                     'greater than 200 mL/100 g/min.'

--- a/aslprep/tests/test_utils_confounds.py
+++ b/aslprep/tests/test_utils_confounds.py
@@ -1,0 +1,194 @@
+"""Tests for aslprep.utils.confounds.compute_cbf_threshold_stats."""
+
+import json
+import os
+
+import nibabel as nb
+import numpy as np
+import pandas as pd
+import pytest
+
+from aslprep.utils.confounds import compute_cbf_threshold_stats
+
+
+def _save_img(arr, tmpdir, fname):
+    """Persist a numpy array as a NIfTI-1 image and return the file path."""
+    img = nb.Nifti1Image(arr, affine=np.eye(4))
+    fpath = os.path.join(str(tmpdir), fname)
+    img.to_filename(fpath)
+    return fpath
+
+
+def test_threshold_stats_basic():
+    """Test compute_cbf_threshold_stats with a simple 3D array."""
+    # 10 voxels: 10, 20, 30, ..., 100
+    cbf = np.arange(10, 110, 10, dtype=float).reshape(2, 5, 1)
+    mask = np.ones_like(cbf, dtype=np.uint8)
+
+    result = compute_cbf_threshold_stats(cbf, mask, thresholds=(50,))
+    # 60, 70, 80, 90, 100 are > 50, so 5 out of 10
+    assert result['perc_voxels_cbf_gt_50'] == pytest.approx(50.0)
+
+
+def test_threshold_stats_4d_input():
+    """A 4D CBF image should be averaged across time before thresholding."""
+    vol_lo = np.full((2, 2, 2), 80.0)
+    vol_hi = np.full((2, 2, 2), 120.0)
+    cbf_4d = np.stack([vol_lo, vol_hi], axis=3)  # mean = 100.0 everywhere
+    mask = np.ones((2, 2, 2), dtype=np.uint8)
+
+    result = compute_cbf_threshold_stats(cbf_4d, mask, thresholds=(100,))
+    assert result['perc_voxels_cbf_gt_100'] == pytest.approx(0.0)  # 100 is NOT > 100
+
+    result = compute_cbf_threshold_stats(cbf_4d, mask, thresholds=(99,))
+    assert result['perc_voxels_cbf_gt_99'] == pytest.approx(100.0)
+
+
+def test_threshold_stats_nan_voxels():
+    """NaN voxels should be excluded from both numerator and denominator."""
+    cbf = np.array([200.0, np.nan, 50.0, np.nan, 150.0]).reshape(5, 1, 1)
+    mask = np.ones((5, 1, 1), dtype=np.uint8)
+
+    result = compute_cbf_threshold_stats(cbf, mask, thresholds=(100,))
+    # 3 valid voxels (200, 50, 150), 2 of them > 100
+    assert result['perc_voxels_cbf_gt_100'] == pytest.approx(200.0 / 3.0)
+
+
+def test_threshold_stats_empty_mask():
+    """When no voxels are inside the mask, all results should be NaN."""
+    cbf = np.array([100.0, 200.0, 300.0]).reshape(3, 1, 1)
+    mask = np.zeros((3, 1, 1), dtype=np.uint8)
+
+    result = compute_cbf_threshold_stats(cbf, mask)
+    for val in result.values():
+        assert np.isnan(val)
+
+
+def test_threshold_stats_all_above():
+    """If every voxel is above every threshold, all percentages should be 100."""
+    cbf = np.full((3, 3, 3), 250.0)
+    mask = np.ones_like(cbf, dtype=np.uint8)
+
+    result = compute_cbf_threshold_stats(cbf, mask)
+    assert result['perc_voxels_cbf_gt_100'] == pytest.approx(100.0)
+    assert result['perc_voxels_cbf_gt_150'] == pytest.approx(100.0)
+    assert result['perc_voxels_cbf_gt_200'] == pytest.approx(100.0)
+
+
+def test_threshold_stats_all_below():
+    """If every voxel is below every threshold, all percentages should be 0."""
+    cbf = np.full((3, 3, 3), 10.0)
+    mask = np.ones_like(cbf, dtype=np.uint8)
+
+    result = compute_cbf_threshold_stats(cbf, mask)
+    assert result['perc_voxels_cbf_gt_100'] == pytest.approx(0.0)
+    assert result['perc_voxels_cbf_gt_150'] == pytest.approx(0.0)
+    assert result['perc_voxels_cbf_gt_200'] == pytest.approx(0.0)
+
+
+def test_threshold_stats_custom_thresholds():
+    """Non-default threshold values should work the same way."""
+    cbf = np.array([10.0, 30.0, 50.0, 70.0]).reshape(2, 2, 1)
+    mask = np.ones((2, 2, 1), dtype=np.uint8)
+
+    result = compute_cbf_threshold_stats(cbf, mask, thresholds=(20, 60))
+    assert result['perc_voxels_cbf_gt_20'] == pytest.approx(75.0)  # 30, 50, 70
+    assert result['perc_voxels_cbf_gt_60'] == pytest.approx(25.0)  # 70
+
+
+def test_threshold_stats_strict_gt():
+    """Values exactly equal to the threshold must NOT be counted."""
+    cbf = np.array([100.0, 100.0, 100.0, 101.0]).reshape(2, 2, 1)
+    mask = np.ones((2, 2, 1), dtype=np.uint8)
+
+    result = compute_cbf_threshold_stats(cbf, mask, thresholds=(100,))
+    # only 101 is strictly > 100
+    assert result['perc_voxels_cbf_gt_100'] == pytest.approx(25.0)
+
+
+def test_threshold_stats_from_nifti_paths(tmp_path):
+    """The function should also accept NIfTI file paths, not just arrays."""
+    cbf_data = np.full((5, 5, 5), 160.0)
+    mask_data = np.ones((5, 5, 5), dtype=np.uint8)
+
+    cbf_file = _save_img(cbf_data, tmp_path, 'cbf.nii.gz')
+    mask_file = _save_img(mask_data, tmp_path, 'mask.nii.gz')
+
+    result = compute_cbf_threshold_stats(cbf_file, mask_file)
+    assert result['perc_voxels_cbf_gt_100'] == pytest.approx(100.0)
+    assert result['perc_voxels_cbf_gt_150'] == pytest.approx(100.0)
+    assert result['perc_voxels_cbf_gt_200'] == pytest.approx(0.0)
+
+
+def test_cbf_qc_interface_threshold_columns(tmp_path):
+    """ComputeCBFQC should write threshold columns to the output TSV and metadata JSON."""
+    from aslprep.interfaces.confounds import ComputeCBFQC
+
+    shape = (10, 10, 10)
+
+    # half the brain at 50, half at 160
+    cbf_data = np.full(shape, 50.0, dtype=np.float32)
+    cbf_data[5:, :, :] = 160.0
+    mean_cbf = _save_img(cbf_data, tmp_path, 'mean_cbf.nii.gz')
+
+    # tissue probability maps
+    gm = np.zeros(shape, dtype=np.float32)
+    gm[2:8, 2:8, 2:8] = 0.9
+    wm = np.zeros(shape, dtype=np.float32)
+    wm[0:2, :, :] = 0.9
+    csf = np.zeros(shape, dtype=np.float32)
+    csf[8:, :, :] = 0.9
+
+    mask = np.ones(shape, dtype=np.uint8)
+
+    # minimal confounds file
+    confounds_df = pd.DataFrame({
+        'framewise_displacement': [0.1, 0.2, 0.15],
+        'rmsd': [0.05, 0.06, 0.04],
+    })
+    confounds_file = os.path.join(str(tmp_path), 'confounds.tsv')
+    confounds_df.to_csv(confounds_file, sep='\t', index=False)
+
+    # name_source must look like a BIDS filename (used for entity extraction)
+    name_source = _save_img(np.zeros(shape, dtype=np.float32), tmp_path, 'sub-01_asl.nii.gz')
+
+    interface = ComputeCBFQC(
+        name_source=name_source,
+        mean_cbf=mean_cbf,
+        gm_tpm=_save_img(gm, tmp_path, 'gm.nii.gz'),
+        wm_tpm=_save_img(wm, tmp_path, 'wm.nii.gz'),
+        csf_tpm=_save_img(csf, tmp_path, 'csf.nii.gz'),
+        asl_mask=_save_img(mask, tmp_path, 'asl_mask.nii.gz'),
+        t1w_mask=_save_img(mask, tmp_path, 't1w_mask.nii.gz'),
+        confounds_file=confounds_file,
+    )
+    results = interface.run(cwd=str(tmp_path))
+
+    # --- check the TSV ---
+    qc_df = pd.read_csv(results.outputs.qc_file, sep='\t')
+
+    # mean CBF columns should be present and non-NaN
+    for thresh in (100, 150, 200):
+        col = f'perc_voxels_cbf_gt_{thresh}'
+        assert col in qc_df.columns, f'{col} missing from QC TSV'
+        assert not pd.isna(qc_df[col].iloc[0]), f'{col} should not be NaN'
+
+    # SCORE/SCRUB/BASIL columns should exist (NaN since those maps were not provided)
+    for variant in ('score', 'scrub', 'basil', 'basil_gm'):
+        for thresh in (100, 150, 200):
+            col = f'perc_voxels_cbf_{variant}_gt_{thresh}'
+            assert col in qc_df.columns, f'{col} missing from QC TSV'
+
+    # spot-check the actual values (half at 50, half at 160)
+    assert qc_df['perc_voxels_cbf_gt_100'].iloc[0] == pytest.approx(50.0)
+    assert qc_df['perc_voxels_cbf_gt_150'].iloc[0] == pytest.approx(50.0)
+    assert qc_df['perc_voxels_cbf_gt_200'].iloc[0] == pytest.approx(0.0)
+
+    # --- check the metadata JSON ---
+    with open(results.outputs.qc_metadata) as f:
+        metadata = json.load(f)
+
+    for thresh in (100, 150, 200):
+        key = f'perc_voxels_cbf_gt_{thresh}'
+        assert key in metadata, f'{key} missing from metadata JSON'
+        assert metadata[key]['Units'] == 'percent'

--- a/aslprep/tests/test_utils_confounds.py
+++ b/aslprep/tests/test_utils_confounds.py
@@ -142,10 +142,12 @@ def test_cbf_qc_interface_threshold_columns(tmp_path):
     mask = np.ones(shape, dtype=np.uint8)
 
     # minimal confounds file
-    confounds_df = pd.DataFrame({
-        'framewise_displacement': [0.1, 0.2, 0.15],
-        'rmsd': [0.05, 0.06, 0.04],
-    })
+    confounds_df = pd.DataFrame(
+        {
+            'framewise_displacement': [0.1, 0.2, 0.15],
+            'rmsd': [0.05, 0.06, 0.04],
+        }
+    )
     confounds_file = os.path.join(str(tmp_path), 'confounds.tsv')
     confounds_df.to_csv(confounds_file, sep='\t', index=False)
 

--- a/aslprep/utils/confounds.py
+++ b/aslprep/utils/confounds.py
@@ -9,6 +9,8 @@ import pandas as pd
 from nibabel.processing import smooth_image
 from nipype.interfaces.base import isdefined
 
+# Default cbf thresholds (mL/100 g/min) for computing voxel percentages
+CBF_THRESH_DEFAULTS = (100, 150, 200)
 
 def _less_breakable(a_string):
     """Harden the string to different environments, whatever that means."""
@@ -231,6 +233,50 @@ def average_cbf_by_tissue(cbf, gm, wm, csf, thresh):
         mean_tissue_cbfs.append(mean_tissue_cbf)
 
     return mean_tissue_cbfs
+
+
+def compute_cbf_threshold_stats(cbf, mask, thresholds=CBF_THRESH_DEFAULTS):
+    """
+Calculates the percentage of in-mask voxels that exceed certain specified cbf thresholds 
+   
+Args : 
+    cbf: path or array of cbf data
+    mask: path or array of binary brain mask
+    thresholds: cutoff to check against (default: 100, 150, 200)
+
+Returns :
+    a dictionary of percentages like {'perc_voxels_cbf_gt_100': 45.2}
+    returns Nan if mask is empty
+    """
+    if isinstance(cbf, str):
+        cbf_data = nb.load(cbf).get_fdata()
+    else:
+        cbf_data = np.array(cbf, dtype=float)
+
+    if cbf_data.ndim > 3:
+        cbf_data = np.nanmean(cbf_data, axis=3)
+
+    if isinstance(mask, str):
+        mask_data = nb.load(mask).get_fdata()
+    else:
+        mask_data = np.asarray(mask)
+
+    mask_bool = mask_data > 0
+    masked_cbf = cbf_data[mask_bool]
+
+    # Drop NaN voxels so they dont skew the stats
+    masked_cbf = masked_cbf[~np.isnan(masked_cbf)]
+    n_voxels = masked_cbf.size
+
+    stats = {}
+    for thresh in thresholds:
+        if n_voxels == 0:
+            stats[f'perc_voxels_cbf_gt_{int(thresh)}'] = np.nan
+        else:
+            n_above = np.sum(masked_cbf > thresh)
+            stats[f'perc_voxels_cbf_gt_{int(thresh)}'] = 100.0 * n_above / n_voxels
+
+    return stats
 
 
 def _load_one_image(nii_file):

--- a/aslprep/utils/confounds.py
+++ b/aslprep/utils/confounds.py
@@ -12,6 +12,7 @@ from nipype.interfaces.base import isdefined
 # Default cbf thresholds (mL/100 g/min) for computing voxel percentages
 CBF_THRESH_DEFAULTS = (100, 150, 200)
 
+
 def _less_breakable(a_string):
     """Harden the string to different environments, whatever that means."""
     return ''.join(a_string.split()).strip('#')

--- a/aslprep/utils/confounds.py
+++ b/aslprep/utils/confounds.py
@@ -236,17 +236,16 @@ def average_cbf_by_tissue(cbf, gm, wm, csf, thresh):
 
 
 def compute_cbf_threshold_stats(cbf, mask, thresholds=CBF_THRESH_DEFAULTS):
-    """
-    Calculates the percentage of in-mask voxels that exceed certain specified cbf thresholds 
-   
-    Args : 
-    cbf: path or array of cbf data
-    mask: path or array of binary brain mask
-    thresholds: cutoff to check against (default: 100, 150, 200)
+    """Compute the percentage of in-mask voxels that exceed specified CBF thresholds.
 
-    Returns :
-    a dictionary of percentages like {'perc_voxels_cbf_gt_100': 45.2}
-    returns Nan if mask is empty
+    Args:
+        cbf: path or array of cbf data
+        mask: path or array of binary brain mask
+        thresholds: cutoff to check against (default: 100, 150, 200)
+
+    Returns:
+        a dictionary of percentages like {'perc_voxels_cbf_gt_100': 45.2}
+        returns NaN if mask is empty
     """
     if isinstance(cbf, str):
         cbf_data = nb.load(cbf).get_fdata()

--- a/aslprep/utils/confounds.py
+++ b/aslprep/utils/confounds.py
@@ -237,14 +237,14 @@ def average_cbf_by_tissue(cbf, gm, wm, csf, thresh):
 
 def compute_cbf_threshold_stats(cbf, mask, thresholds=CBF_THRESH_DEFAULTS):
     """
-Calculates the percentage of in-mask voxels that exceed certain specified cbf thresholds 
+    Calculates the percentage of in-mask voxels that exceed certain specified cbf thresholds 
    
-Args : 
+    Args : 
     cbf: path or array of cbf data
     mask: path or array of binary brain mask
     thresholds: cutoff to check against (default: 100, 150, 200)
 
-Returns :
+    Returns :
     a dictionary of percentages like {'perc_voxels_cbf_gt_100': 45.2}
     returns Nan if mask is empty
     """


### PR DESCRIPTION
 Closes #606 

Adds QC measures that report the % of in-mask voxels with cbf values strictly greater than (gt) 100, 150, 200 mL/100g/min

CHANGES
-> Added 'compute_cbf_threshold_stats()' utility and 'CBF_THRESH_DEFAULT' constant to 'aslprep/utils/confounds.py' .
-> Integrated threshold stats into 'ComputeCBFQC' for all 5 types of cbf map types (mean, SCORE, SCRUB, BASIL, BASIL GM-PVC) with bids-compliant metadata .
-> In the 'aslprep/tests/test_utils_confounds.py' , features like basic computation, 4d reduction, NaN handling, empty mask, boundary conditions, stricter gt semantics are tested .

No external documentation changes needed.