### PR TITLE
Retain minc_modify_header and mincreshape in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-ARG BASE_IMAGE=pennlinc/aslprep-base:20260224
+ARG BASE_IMAGE=pennlinc/aslprep-base:20260416
 
 #
 # Build pixi environment

--- a/docker/files/freesurfer7.3.2-exclude.txt
+++ b/docker/files/freesurfer7.3.2-exclude.txt
@@ -795,9 +795,7 @@ freesurfer/mni/bin/minclookup
 freesurfer/mni/bin/mincmakescalar
 freesurfer/mni/bin/mincmakevector
 freesurfer/mni/bin/mincmath
-freesurfer/mni/bin/minc_modify_header
 freesurfer/mni/bin/mincpik
-freesurfer/mni/bin/mincreshape
 freesurfer/mni/bin/mincstats
 freesurfer/mni/bin/minctoecat
 freesurfer/mni/bin/minctoraw


### PR DESCRIPTION
This should fix an issue identified by Ashley Francisco in her tilted images.