### PR TITLE
Write out aBV computed by BASIL for multi-PLD data

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - run: pipx run ruff check .
-      - run: pipx run ruff format --diff .
+      # Keep this pin in sync with the ruff rev in .pre-commit-config.yaml.
+      # Unpinned, CI silently follows new ruff releases and goes red without a code change.
+      - run: pipx run --spec ruff==0.14.11 ruff check .
+      - run: pipx run --spec ruff==0.14.11 ruff format --diff .
 
   codespell:
     name: Check for spelling errors

--- a/aslprep/interfaces/cbf.py
+++ b/aslprep/interfaces/cbf.py
@@ -953,7 +953,9 @@ class BASILCBF(FSLCommand):
             'native_space/pvcorr/perfusion_wm_calib.nii.gz',
         )
 
-        # TODO: Make these two conditional on having multi-PLD data
+        # oxford_asl produces these regardless of the number of PLDs, but they are only
+        # meaningful for multi-PLD data. Whether they are surfaced as derivatives is gated
+        # on multi-PLD status in the CBF workflow (see init_cbf_wf).
         outputs['att_basil'] = os.path.abspath('native_space/arrival.nii.gz')
         outputs['abv_basil'] = os.path.abspath('native_space/aCBV_calib.nii.gz')
 

--- a/aslprep/interfaces/cbf.py
+++ b/aslprep/interfaces/cbf.py
@@ -914,6 +914,7 @@ class _BASILCBFOutputSpec(TraitedSpec):
         desc='cbf with spatial partial volume white matter correction',
     )
     att_basil = File(exists=True, desc='arterial transit time')
+    abv_basil = File(exists=True, desc='arterial blood volume')
 
 
 class BASILCBF(FSLCommand):
@@ -945,12 +946,15 @@ class BASILCBF(FSLCommand):
         outputs = self.output_spec().get()
 
         outputs['mean_cbf_basil'] = os.path.abspath('native_space/perfusion_calib.nii.gz')
-        outputs['att_basil'] = os.path.abspath('native_space/arrival.nii.gz')
         outputs['mean_cbf_gm_basil'] = os.path.abspath(
             'native_space/pvcorr/perfusion_calib.nii.gz',
         )
         outputs['mean_cbf_wm_basil'] = os.path.abspath(
             'native_space/pvcorr/perfusion_wm_calib.nii.gz',
         )
+
+        # TODO: Make these two conditional on having multi-PLD data
+        outputs['att_basil'] = os.path.abspath('native_space/arrival.nii.gz')
+        outputs['abv_basil'] = os.path.abspath('native_space/aCBV_calib.nii.gz')
 
         return outputs

--- a/aslprep/interfaces/cbf.py
+++ b/aslprep/interfaces/cbf.py
@@ -953,10 +953,18 @@ class BASILCBF(FSLCommand):
             'native_space/pvcorr/perfusion_wm_calib.nii.gz',
         )
 
-        # oxford_asl produces these regardless of the number of PLDs, but they are only
-        # meaningful for multi-PLD data. Whether they are surfaced as derivatives is gated
-        # on multi-PLD status in the CBF workflow (see init_cbf_wf).
-        outputs['att_basil'] = os.path.abspath('native_space/arrival.nii.gz')
-        outputs['abv_basil'] = os.path.abspath('native_space/aCBV_calib.nii.gz')
+        # These are only meaningful for multi-PLD data, and oxford_asl only writes them when
+        # it infers arterial transit time / the macrovascular (arterial) component. For
+        # single-PLD data these files are not produced, so only report them when they exist
+        # to avoid failing the mandatory existence check during output aggregation. Whether
+        # they are surfaced as derivatives is gated on multi-PLD status in the CBF workflow
+        # (see init_cbf_wf).
+        att_basil = os.path.abspath('native_space/arrival.nii.gz')
+        if os.path.isfile(att_basil):
+            outputs['att_basil'] = att_basil
+
+        abv_basil = os.path.abspath('native_space/aCBV_calib.nii.gz')
+        if os.path.isfile(abv_basil):
+            outputs['abv_basil'] = abv_basil
 
         return outputs

--- a/aslprep/tests/data/expected_outputs_examples_pasl_multipld.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pasl_multipld.txt
@@ -58,6 +58,8 @@ sub-01/perf/sub-01_acq-paslmultipld_desc-basilGM_cbf.json
 sub-01/perf/sub-01_acq-paslmultipld_desc-basilGM_cbf.nii.gz
 sub-01/perf/sub-01_acq-paslmultipld_desc-basilWM_cbf.json
 sub-01/perf/sub-01_acq-paslmultipld_desc-basilWM_cbf.nii.gz
+sub-01/perf/sub-01_acq-paslmultipld_desc-basil_abv.json
+sub-01/perf/sub-01_acq-paslmultipld_desc-basil_abv.nii.gz
 sub-01/perf/sub-01_acq-paslmultipld_desc-basil_att.json
 sub-01/perf/sub-01_acq-paslmultipld_desc-basil_att.nii.gz
 sub-01/perf/sub-01_acq-paslmultipld_desc-basil_cbf.json

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_ge.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_ge.txt
@@ -52,6 +52,8 @@ sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basilGM_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basilGM_cbf.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basilWM_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basilWM_cbf.nii.gz
+sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_abv.json
+sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_abv.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_att.json
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_att.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_cbf.json

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_ge.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_ge.txt
@@ -52,10 +52,6 @@ sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basilGM_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basilGM_cbf.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basilWM_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basilWM_cbf.nii.gz
-sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_abv.json
-sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_abv.nii.gz
-sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_att.json
-sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_att.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-basil_cbf.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldge3d_run-01_desc-brain_mask.json

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_philips.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_philips.txt
@@ -60,6 +60,8 @@ sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basilGM_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basilGM_cbf.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basilWM_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basilWM_cbf.nii.gz
+sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_abv.json
+sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_abv.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_att.json
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_att.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_cbf.json

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_philips.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_philips.txt
@@ -60,10 +60,6 @@ sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basilGM_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basilGM_cbf.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basilWM_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basilWM_cbf.nii.gz
-sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_abv.json
-sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_abv.nii.gz
-sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_att.json
-sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_att.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-basil_cbf.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldphilips2d_desc-brain_mask.json

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_siemens.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_siemens.txt
@@ -74,6 +74,8 @@ sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basilGM_cbf.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basilWM_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basilWM_cbf.nii.gz
+sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_abv.json
+sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_abv.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_att.json
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_att.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_cbf.json

--- a/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_siemens.txt
+++ b/aslprep/tests/data/expected_outputs_examples_pcasl_singlepld_siemens.txt
@@ -74,10 +74,6 @@ sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basilGM_cbf.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basilWM_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basilWM_cbf.nii.gz
-sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_abv.json
-sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_abv.nii.gz
-sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_att.json
-sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_att.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_cbf.json
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-basil_cbf.nii.gz
 sub-01/perf/sub-01_acq-pcaslsinglepldsiemens3d_run-01_space-MNI152NLin2009cAsym_desc-brain_mask.nii.gz

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -258,7 +258,7 @@ def init_asl_wf(
             'mean_cbf_gm_basil',
             'mean_cbf_wm_basil',
         ]
-        att_derivs += ['att_basil']
+        att_derivs += ['att_basil', 'abv_basil']
 
     cbf_derivs = att_derivs + cbf_3d_derivs + cbf_4d_derivs
 

--- a/aslprep/workflows/asl/base.py
+++ b/aslprep/workflows/asl/base.py
@@ -258,7 +258,9 @@ def init_asl_wf(
             'mean_cbf_gm_basil',
             'mean_cbf_wm_basil',
         ]
-        att_derivs += ['att_basil', 'abv_basil']
+        if is_multi_pld:
+            # BASIL's ATT and aBV estimates are only meaningful for multi-PLD data.
+            att_derivs += ['att_basil', 'abv_basil']
 
     cbf_derivs = att_derivs + cbf_3d_derivs + cbf_4d_derivs
 

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -488,11 +488,17 @@ additionally calculates a partial-volume corrected CBF image [@chappell_pvc].
                 ('mean_cbf_basil', 'mean_cbf_basil'),
                 ('mean_cbf_gm_basil', 'mean_cbf_gm_basil'),
                 ('mean_cbf_wm_basil', 'mean_cbf_wm_basil'),
-                # TODO: Make these two conditional on having multi-PLD data
-                ('att_basil', 'att_basil'),
-                ('abv_basil', 'abv_basil'),
             ]),
         ])  # fmt:skip
+
+        if is_multi_pld:
+            # BASIL's ATT and aBV estimates are only meaningful for multi-PLD data.
+            workflow.connect([
+                (basilcbf, outputnode, [
+                    ('att_basil', 'att_basil'),
+                    ('abv_basil', 'abv_basil'),
+                ]),
+            ])  # fmt:skip
 
         if metadata['M0Type'] != 'Estimate':
             workflow.connect([(extract_deltam, basilcbf, [('m0tr', 'm0tr')])])

--- a/aslprep/workflows/asl/cbf.py
+++ b/aslprep/workflows/asl/cbf.py
@@ -247,6 +247,7 @@ using the {bcut} modification, as described in {singlepld_pasl_strs[bcut]}.
                 'mean_cbf_gm_basil',
                 'mean_cbf_wm_basil',
                 'att_basil',
+                'abv_basil',
             ]
         ),
         name='outputnode',
@@ -487,7 +488,9 @@ additionally calculates a partial-volume corrected CBF image [@chappell_pvc].
                 ('mean_cbf_basil', 'mean_cbf_basil'),
                 ('mean_cbf_gm_basil', 'mean_cbf_gm_basil'),
                 ('mean_cbf_wm_basil', 'mean_cbf_wm_basil'),
+                # TODO: Make these two conditional on having multi-PLD data
                 ('att_basil', 'att_basil'),
+                ('abv_basil', 'abv_basil'),
             ]),
         ])  # fmt:skip
 

--- a/aslprep/workflows/asl/outputs.py
+++ b/aslprep/workflows/asl/outputs.py
@@ -112,6 +112,15 @@ BASE_INPUT_FIELDS = {
             'The time taken for the labeled blood water to reach the voxel.'
         ),
     },
+    'abv_basil': {
+        'desc': 'basil',
+        'suffix': 'abv',
+        'Units': 'fraction',
+        'Description': (
+            'Arterial (cerebral) blood volume, estimated by BASIL. '
+            'The fraction of the voxel occupied by the arterial vessel.'
+        ),
+    },
 }
 
 

--- a/aslprep/workflows/asl/plotting.py
+++ b/aslprep/workflows/asl/plotting.py
@@ -77,6 +77,7 @@ def init_cbf_reporting_wf(
                 'mean_cbf_gm_basil',
                 'mean_cbf_wm_basil',  # unused
                 'att_basil',  # unused
+                'abv_basil',  # unused
             ],
         ),
         name='inputnode',

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -346,7 +346,8 @@ If ``--basil`` is used::
          <source_entities>[_space-<label>]_desc-basil_cbf.nii.gz  # mean CBF computed with BASIL
          <source_entities>[_space-<label>]_desc-basilGM_cbf.nii.gz  # GM partial volume corrected CBF with BASIL
          <source_entities>[_space-<label>]_desc-basilWM_cbf.nii.gz  # WM partial volume corrected CBF with BASIL
-         <source_entities>[_space-<label>]_att.nii.gz  # bolus arrival time/arterial transit time (in seconds)
+         <source_entities>[_space-<label>]_desc-basil_att.nii.gz  # arterial transit time (multi-PLD data only)
+         <source_entities>[_space-<label>]_desc-basil_abv.nii.gz  # arterial blood volume (multi-PLD data only)
 
 
 *************


### PR DESCRIPTION
Closes #667.

## Changes proposed in this pull request

- Write out BASIL-estimated aBV (written by oxford_asl as aCBV_calib.nii.gz).
- Gate BASIL-estimated aBV and ATT (written by oxford_asl as arrival.nii.gz) so they're only written out to ASLPrep derivatives if the data are multi-PLD.