### PR TITLE
Sync CI setup across LINC BIDS Apps

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -87,9 +87,15 @@ commands:
   restore_build_and_data:
     description: Restore Docker image cache and test data cache, then start the registry
     steps:
+      # Restore the workflow-scoped key, not the shared deps key. CircleCI
+      # caches are immutable: if image_prep rebuilt the test image but the
+      # deps key already existed, its save_cache would be a no-op and this
+      # job would pull a stale image from an earlier run's registry. The
+      # workflow-scoped key is unique per run, so it always reflects the
+      # image image_prep actually produced.
       - restore_cache:
           keys:
-            - build-v4-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
+            - build-v5-workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
       - restore_cache:
           keys:
             - data-v2-{{ checksum ".circleci/data_versions.txt" }}
@@ -170,7 +176,7 @@ jobs:
           path: /tmp/src/aslprep
       - restore_cache:
           keys:
-            - build-v4-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
+            - build-v5-deps-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
       - run: *docker_auth
       - run: *setup_docker_registry
       - run:
@@ -198,6 +204,7 @@ jobs:
             if ! docker manifest inspect $BASE_IMAGE > /dev/null 2>&1; then
               echo "Base image $BASE_IMAGE not found, building..."
               docker build -f Dockerfile.base \
+                --pull \
                 --platform linux/amd64 \
                 -t $BASE_IMAGE \
                 -t $BASE_IMAGE_NAME:latest .
@@ -355,8 +362,19 @@ jobs:
           command: |
             mkdir -p /tmp/images
             touch /tmp/images/imageprep-success.marker
+      # Two keys on purpose. The workflow-scoped key is unique per run so it
+      # is always written, guaranteeing downstream jobs restore the image
+      # this run actually produced. The deps key is shared across runs with
+      # identical Docker inputs and is what lets a later run skip the build
+      # entirely; it is a no-op once it exists, which is why it cannot be
+      # the key downstream jobs read from.
       - save_cache:
-          key: build-v4-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
+          key: build-v5-workflow-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
+          paths:
+            - /tmp/docker
+            - /tmp/images
+      - save_cache:
+          key: build-v5-deps-{{ checksum "Dockerfile" }}-{{ checksum "pixi.lock" }}
           paths:
             - /tmp/docker
             - /tmp/images

--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,4 @@ Dockerfile*    text eol=lf
 *.png      binary
 *.jpg      binary
 *.nii.gz   binary
+*.gpg      binary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,11 +88,20 @@ The config module is the single source of truth for runtime parameters. Never pa
 
 ### Docker
 
-- Each app has a base image with runtime dependencies and a main Dockerfile that installs the Python environment and the app itself.
-- ASLPrep, fMRIPrep, and XCP-D have migrated to **Pixi**-based multi-stage Docker builds: `Dockerfile.base` owns non-Python/non-conda runtime dependencies, while `Dockerfile` uses pixi to create `build`, `test`, and production targets from `pixi.lock`. qsiprep and qsirecon still use micromamba + `pip install`.
-- Base image naming: ASLPrep and XCP-D use date-based tags (`pennlinc/<pkg>-base:<YYYYMMDD>`); qsiprep and qsirecon use `pennlinc/<pkg>_build:<version>`.
+- Each app has a base image with runtime dependencies (`Dockerfile.base`) and a main `Dockerfile` that installs the Python environment and the app itself.
+- All four apps use **Pixi**-based multi-stage Docker builds: `Dockerfile.base` owns non-Python/non-conda runtime dependencies, while `Dockerfile` uses pixi to create `build`, `test`, and production targets from `pixi.lock`.
+- Base image naming is uniform across the four repos: `pennlinc/<pkg>-base:<YYYYMMDD>`, pinned via `ARG BASE_IMAGE` on the first line of `Dockerfile`.
 - Entrypoint is the CLI binary in the pixi environment (e.g., `/app/.pixi/envs/<env>/bin/<pkg>`).
-- Labels follow the `org.label-schema` convention.
+- Labels follow the `org.label-schema` convention; the `test` target additionally carries `org.opencontainers.image.revision`, which CI uses to refuse running tests against a stale image.
+- The base image is rebuilt only when its `BASE_IMAGE` tag is absent from Docker Hub. Editing `Dockerfile.base` without bumping the date tag does **not** trigger a rebuild.
+
+### CircleCI
+
+- All four repos use CircleCI **dynamic configuration**. `.circleci/config.yml` is a `setup: true` workflow that runs the `path-filtering` orb and hands off to `.circleci/continue_config.yml`, which holds the real pipeline. A docs-only push leaves `has_code_changes` false and skips the expensive matrix.
+- `continue_config.yml` defines two workflows: `run_tests` (branch pushes, gated on `has_code_changes`) and `deploy` (tag pushes only, which skips the matrix since the tagged commit already passed on `main`).
+- `image_prep` builds the base image (only if its tag is missing), the `test` image, and — on `main` and tags only — the production image, then pushes to Docker Hub. Integration jobs consume the test image from a local registry seeded out of the build cache.
+- The build cache uses two keys: a workflow-scoped key that downstream jobs read from (unique per run, so always written) and a shared `-deps-` key on `Dockerfile` + `pixi.lock` checksums that lets a later run skip the build entirely. Downstream jobs must not read the deps key — CircleCI caches are immutable, so it can point at an older run's image.
+- Docker Hub credentials are **not** named consistently yet: aslprep and xcp_d use `$DOCKERHUB_USERNAME`/`$DOCKERHUB_TOKEN`, qsiprep and qsirecon use `$DOCKER_USER`/`$DOCKER_PASS`. Logins are guarded by a `[[ -n ... ]]` check, so an unset variable skips login silently rather than failing.
 
 ### Release Process
 
@@ -201,11 +210,11 @@ ASLPrep now follows the same CI trigger-condition pattern as XCP-D:
   - Lockfile update steps run only when latest commit touched `pyproject.toml` or `pixi.lock`.
   - Lockfile push-back is restricted to same-repo PR branches; fork PRs do not push.
 
-- **CircleCI image workflow** (`.circleci/config.yml`):
-  - Image rebuild trigger uses cache marker restoration keyed by `Dockerfile` + `pixi.lock` checksums (`build-v3-...`).
-  - Editing `Dockerfile` or `pixi.lock` invalidates cache marker and triggers production/test image rebuild.
-  - Base image rebuild remains controlled by `BASE_IMAGE` manifest existence; `Dockerfile.base` edits alone do not force rebuild when tag exists.
-  - Branch/tag filters are workflow-level (not file-path filters): `image_prep` on all branches/tags, deploy only on `main` and tags.
+- **CircleCI image workflow** (`.circleci/continue_config.yml` — `config.yml` is only the path-filtering setup workflow):
+  - Image rebuild trigger uses cache marker restoration keyed by `Dockerfile` + `pixi.lock` checksums (`build-v5-...`).
+  - Editing `Dockerfile` or `pixi.lock` invalidates the cache marker and triggers a production/test image rebuild.
+  - Base image rebuild remains controlled by `BASE_IMAGE` manifest existence; `Dockerfile.base` edits alone do not force a rebuild when the tag exists.
+  - Gating is two-layered: file-path filters in `config.yml` decide whether the continuation pipeline runs at all, and workflow-level branch/tag filters inside `continue_config.yml` then split branch pushes (`run_tests`) from tag pushes (`deploy`). The production image is built and pushed from `image_prep` itself, on `main` pushes and tags only.
 
 ### Linting Notes
 
@@ -250,7 +259,7 @@ This roadmap covers harmonization work across all four PennLINC BIDS Apps (qsipr
 ### Phase 3: Shared infrastructure
 
 11. **Extract a reusable GitHub Actions workflow** for lint + codespell + build checks, hosted in a shared repo (e.g., `PennLINC/.github`).
-12. **Standardize Dockerfile patterns** -- ASLPrep, fMRIPrep, and XCP-D have adopted pixi-based multi-stage Docker builds. Migrate qsiprep and qsirecon to the same pattern.
+12. ~~**Standardize Dockerfile patterns**~~ -- done: all four repos now use pixi-based multi-stage builds with `pennlinc/<pkg>-base:<YYYYMMDD>` base images.
 13. **Create a shared `pennlinc-style` package or cookiecutter template** providing `pyproject.toml` lint/test config, `.pre-commit-config.yaml`, `tox.ini`, and CI workflows.
 14. **Evaluate `nipreps-versions` calver** -- the `raw-options = { version_scheme = "nipreps-calver" }` line is commented out in all four repos. Decide whether to adopt it.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ARG BASE_IMAGE=pennlinc/aslprep-base:20260416
 #   - TensorFlow, PyTorch (via conda-forge)
 #   - ...
 #
-FROM ghcr.io/prefix-dev/pixi:0.53.0 AS build
+FROM ghcr.io/prefix-dev/pixi:0.58.0 AS build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
                     ca-certificates \
@@ -119,6 +119,8 @@ ENV PATH="/app/.pixi/envs/aslprep/bin:$PATH"
 ENV FSLDIR="/app/.pixi/envs/aslprep"
 
 ENV IS_DOCKER_8395080871=1
+# Verify the runtime image can import aslprep without source tree mounts.
+RUN /app/.pixi/envs/aslprep/bin/python -c "import aslprep"
 
 ENTRYPOINT ["/app/.pixi/envs/aslprep/bin/aslprep"]
 


### PR DESCRIPTION
Regular synchronization of CircleCI/Docker setups across the lab's BIDS Apps.

Related to https://github.com/PennLINC/xcp_d/pull/1632, https://github.com/PennLINC/qsiprep/pull/1075, and https://github.com/PennLINC/qsirecon/pull/395.

### Summary

  aslprep has the most evolved CircleCI workflow of the four PennLINC BIDS Apps,
  but it was behind on three points. The most important is a real correctness bug
  in the build cache.

  `restore_build_and_data` restored the same key that `image_prep` saves
  (`build-v4-{{ checksum Dockerfile }}-{{ checksum pixi.lock }}`). CircleCI caches
  are **immutable** — once that key exists, `save_cache` is a silent no-op. So when
  `image_prep` genuinely rebuilt the test image (e.g. `BASE_WAS_BUILT=1`),
  downstream integration jobs would restore an *earlier* run's registry and test
  against a stale image. This adopts the two-key scheme xcp_d and qsiprep already
  use, where downstream jobs read a workflow-scoped key that is always written.

  ### Changes

  - **`.circleci/continue_config.yml`**
    - Split the build cache into two keys: `build-v5-workflow-{{ CIRCLE_WORKFLOW_ID }}-…`
      (unique per run, always written, read by downstream jobs) and
      `build-v5-deps-…` (shared, lets a later run skip the build). Version bumped
      v4 → v5 to invalidate the old single-key caches.
    - `image_prep` now restores the `-deps-` key; `restore_build_and_data` restores
      the `-workflow-` key.
    - Added `--pull` to the `Dockerfile.base` build so base rebuilds refresh their
      upstream `FROM` images.
    - Comments explaining the two-key invariant, so it isn't collapsed back.
  - **`Dockerfile`**
    - pixi `0.53.0` → `0.58.0`, matching the other three repos. All four `pixi.lock`
      files are lockfile `version: 6`, so this is a drop-in change.
    - Added `RUN /app/.pixi/envs/aslprep/bin/python -c "import aslprep"` to the
      production stage. xcp_d, qsiprep and qsirecon all had this guard; aslprep did not.
  - **`.gitattributes`** — added `*.gpg binary`.
  - **`AGENTS.md`** — see "Docs were wrong" below.

  ### Docs corrections

  The shared docs claimed qsiprep and qsirecon "still use micromamba + `pip install`"
  with `pennlinc/<pkg>_build:<version>` base images — false since both migrated to
  pixi. aslprep-specific fixes:

  - Cache prefix `build-v3-` → `build-v5-` (it was already v4 before this PR).
  - The image workflow lives in `continue_config.yml`, not `config.yml`.
  - "Branch/tag filters are workflow-level (not file-path filters)" stated the
    opposite of current behavior — aslprep has used path filtering since the
    dynamic-config migration.
  - Added a shared `### CircleCI` section documenting the two-key cache invariant.
  - Recommendation #12 ("migrate qsiprep and qsirecon to pixi") struck as done.

  ### Verification

  - `.circleci/config.yml` and `continue_config.yml` parse as valid YAML.
  - Cache keys cross-checked for restore/save consistency.
  - Job and workflow structure compared against the other three repos.

  **Not verified:** no CircleCI run, no Docker build, no test execution. The pixi
  bump and the `import aslprep` guard both need a real image build to confirm.